### PR TITLE
generatedSourceDir should do exactly what it says. 

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -239,7 +239,7 @@ class ProtobufPlugin implements Plugin<Project> {
 
     private getGeneratedSourceDir(Project project, SourceSet sourceSet) {
         def generatedSourceDir = project.convention.plugins.protobuf.generatedFileDir
-        return "${generatedSourceDir}/${sourceSet.name}"
+        return "${generatedSourceDir}"
     }
 
 }


### PR DESCRIPTION
It not only looks bad, but also causes problem in setting up directory structure when  sourceSet.name is artificially added to it. In normal gradle

Issue generatedFileDir does not follow Gradle Java Plugin conventions (nor can you) #16