### PR TITLE
Adds option generateDescriptorSet to GenerateProtoTask.

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -63,6 +63,14 @@ public class GenerateProtoTask extends DefaultTask {
   private String buildType
   private boolean isTestVariant
 
+  /**
+   * If true, will set the protoc flag
+   * --descriptor_set_out="${outputBaseDir}/descriptor_set.desc"
+   *
+   * Default: false
+   */
+  public boolean generateDescriptorSet
+
   private static enum State {
     INIT, CONFIG, FINALIZED
   }
@@ -302,6 +310,10 @@ public class GenerateProtoTask extends DefaultTask {
       String pluginOutPrefix = makeOptionsPrefix(plugin.options)
       cmd += "--${name}_out=${pluginOutPrefix}${getOutputDir(plugin)}"
       cmd += "--plugin=protoc-gen-${name}=${locator.path}"
+    }
+
+    if (generateDescriptorSet) {
+      cmd += "--descriptor_set_out=${outputBaseDir}/descriptor_set.desc"
     }
 
     cmd.addAll protoFiles

--- a/testProject/build.gradle
+++ b/testProject/build.gradle
@@ -81,6 +81,7 @@ protobuf {
           option 'nano=true'
         }
       }
+      task.generateDescriptorSet = true
     }
   }
 }
@@ -96,6 +97,14 @@ jar {
 def assertJavaCompileHasProtoGeneratedDir(String sourceSet, Collection<String> codegenPlugins) {
   def compileJavaTask = tasks.getByName(sourceSets.getByName(sourceSet).getCompileTaskName("java"))
   assertJavaCompileHasProtoGeneratedDir(project, sourceSet, compileJavaTask, codegenPlugins)
+}
+
+def assertFileExists(boolean exists, String path) {
+  if (exists) {
+    org.junit.Assert.assertTrue("\"${path}\" exists", (path as File).exists());
+  } else {
+    org.junit.Assert.assertFalse("\"${path}\" doesn't exist", (path as File).exists());
+  }
 }
 
 test.doLast {
@@ -114,4 +123,10 @@ test.doLast {
   assertJavaCompileHasProtoGeneratedDir('nano', ['javanano'])
   assertJavaCompileHasProtoGeneratedDir('grpc', ['java', 'grpc'])
   assertJavaCompileHasProtoGeneratedDir('grpc_nano', ['javanano', 'grpc'])
+
+  // Check generateDescriptorSet option has been honored
+  ['main', 'test', 'nano', 'grpc'].each { sourceSet ->
+    assertFileExists(false, "$buildDir/generated/source/proto/$sourceSet/descriptor_set.desc")
+  }
+  assertFileExists(true, "$buildDir/generated/source/proto/grpc_nano/descriptor_set.desc")
 }


### PR DESCRIPTION
Default is false. When set to true, the task will add
--descriptor_set_out=build/generated/source/proto/$sourceSet/descriptor_set.desc
to protoc command line.

Resolves #29 

@ejona86 @lomdalf