### PR TITLE
Support incremental build in ProtobufExtract task

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -62,7 +62,9 @@ class ProtobufExtract extends DefaultTask {
   protected void setConfigName(String configName) {
     Preconditions.checkState(this.configName == null, 'configName already set')
     this.configName = configName
-    inputs.files project.configurations[configName]
+    def config = project.configurations[configName]
+    inputs.files config
+    dependsOn config
   }
 
   protected String getConfigName() {

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -29,9 +29,9 @@
  */
 package com.google.protobuf.gradle
 
+import com.google.common.base.Preconditions
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -42,17 +42,37 @@ class ProtobufExtract extends DefaultTask {
   /**
    * The directory for the extracted files.
    */
-  File destDir
+  private File destDir
 
   /**
    * The name of the configuration that contains proto files.
    */
-  String configName
+  private String configName
+
+  protected void setDestDir(File destDir) {
+    Preconditions.checkState(this.destDir == null, 'destDir already set')
+    this.destDir = destDir
+    outputs.dir destDir
+  }
+
+  protected File getDestDir() {
+    return destDir
+  }
+
+  protected void setConfigName(String configName) {
+    Preconditions.checkState(this.configName == null, 'configName already set')
+    this.configName = configName
+    inputs.files project.configurations[configName]
+  }
+
+  protected String getConfigName() {
+    return configName
+  }
 
   @TaskAction
   def extract() {
     logger.debug "Extracting protos from configuration ${configName} to ${destDir}"
-    project.configurations[configName].files.each { file ->
+    inputs.files.each { file ->
       logger.debug "Extracting protos from ${file} to ${destDir}"
       if (file.path.endsWith('.proto')) {
         project.copy {

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -298,7 +298,6 @@ class ProtobufPlugin implements Plugin<Project> {
         description = "Extracts proto files/dependencies specified by 'protobuf' configuration"
         destDir = getExtractedProtosDir(sourceSetName) as File
         configName = Utils.getConfigName(sourceSetName, 'protobuf')
-        dependsOn project.configurations.getByName(configName)
       }
     }
 
@@ -323,7 +322,6 @@ class ProtobufPlugin implements Plugin<Project> {
         description = "Extracts proto files from compile dependencies for includes"
         destDir = getExtractedIncludeProtosDir(sourceSetName) as File
         configName = Utils.getConfigName(sourceSetName, 'compile')
-        dependsOn project.configurations.getByName(configName)
       }
     }
 


### PR DESCRIPTION
I don't use the annotations, because
 1. I would need to create a `getInputFiles()` to put `@InputFiles` on anyway. Registering `inputs` looks slightly simpler.
 2. `GenerateProtoTask` has already been registering `intputs` and `outputs`. Converting it to using annotations is more painful. I'd like to keep the two tasks consistent with this aspect.

According to this [blog post](http://mrhaki.blogspot.com/2010/10/gradle-goodness-add-incremental-build.html), the annotations and the `inputs`/`outputs` properties should have the same effect.

@brunobowden
@Shad0w1nk