### PR TITLE
Adding more configuration options for descriptor generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,16 +310,16 @@ The task also provides following options:
   task.generateDescriptorSet = true
 
   // Allows to override the default for the descriptor set location
-  task.descriptorSetPath = 
-    "${projectDir}/build/descriptors/{$task.sourceSet.name}.dsc
+  task.descriptorSetOptions.path = 
+    "${projectDir}/build/descriptors/{$task.sourceSet.name}.dsc"
 
   // If true, the descriptor set will contain line number information 
   // and comments. Default is false.
-  task.includeSourceInfoInDescriptorSet = true
+  task.descriptorSetOptions.includeSourceInfo = true
 
   // If true, the descriptor set will contain all transitive imports and 
   // is therefore self-contained. Default is false.
-  task.includeImportsInDescriptorSet = true
+  task.descriptorSetOption.includeImports = true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,18 @@ The task also provides following options:
   // $generatedFilesBaseDir/$sourceSet. Default is false.
   // See --descriptor_set_out in protoc documentation about what it is.
   task.generateDescriptorSet = true
+
+  // Allows to override the default for the descriptor set location
+  task.descriptorSetPath = 
+    "${projectDir}/build/descriptors/{$task.sourceSet.name}.dsc
+
+  // If true, the descriptor set will contain line number information 
+  // and comments. Default is false.
+  task.includeSourceInfoInDescriptorSet = true
+
+  // If true, the descriptor set will contain all transitive imports and 
+  // is therefore self-contained. Default is false.
+  task.includeImportsInDescriptorSet = true
 }
 ```
 

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -199,7 +199,8 @@ public class GenerateProtoTask extends DefaultTask {
 
   String getDescriptorPath() {
     if (!generateDescriptorSet) {
-      return null
+      throw new IllegalStateException(
+          "requested descriptor path but descriptor generation is off")
     }
     return descriptorSetOptions.path != null
       ? descriptorSetOptions.path : "${outputBaseDir}/descriptor_set.desc"

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -72,32 +72,40 @@ public class GenerateProtoTask extends DefaultTask {
   public boolean generateDescriptorSet
 
   /**
-   * If set, specifies an alternative location than the default for storing the descriptor
-   * set.
-   *
-   * Default: null
+   * Configuration object for descriptor generation details.
    */
-  public GString descriptorSetPath
+  public class DescriptorSetOptions {
+    /**
+     * If set, specifies an alternative location than the default for storing the descriptor
+     * set.
+     *
+     * Default: null
+     */
+    public GString path
 
-  /**
-   * If true, source information (comments, locations) will be included in the descriptor set.
-   *
-   * Default: false
-   */
-  public boolean includeSourceInfoInDescriptorSet
+    /**
+     * If true, source information (comments, locations) will be included in the descriptor set.
+     *
+     * Default: false
+     */
+    public boolean includeSourceInfo
 
-  /**
-   * If true, imports are included in the descriptor set, such that it is self-containing.
-   *
-   * Default: false
-   */
-  public boolean includeImportsInDescriptorSet
+    /**
+     * If true, imports are included in the descriptor set, such that it is self-containing.
+     *
+     * Default: false
+     */
+    public boolean includeImports
+  }
+
+  public final DescriptorSetOptions descriptorSetOptions = new DescriptorSetOptions();
 
   private static enum State {
     INIT, CONFIG, FINALIZED
   }
 
   private State state = State.INIT
+
 
   private void checkInitializing() {
     Preconditions.checkState(state == State.INIT, 'Should not be called after initilization has finished')
@@ -193,8 +201,8 @@ public class GenerateProtoTask extends DefaultTask {
     if (!generateDescriptorSet) {
       return null
     }
-    return descriptorSetPath != null
-      ? descriptorSetPath : "${outputBaseDir}/descriptor_set.desc"
+    return descriptorSetOptions.path != null
+      ? descriptorSetOptions.path : "${outputBaseDir}/descriptor_set.desc"
   }
 
   public GenerateProtoTask() {
@@ -369,10 +377,10 @@ public class GenerateProtoTask extends DefaultTask {
         folder.mkdirs()
       }
       cmd += "--descriptor_set_out=${path}"
-      if (includeImportsInDescriptorSet) {
+      if (descriptorSetOptions.includeImports) {
         cmd += "--include_imports"
       }
-      if (includeSourceInfoInDescriptorSet) {
+      if (descriptorSetOptions.includeSourceInfo) {
         cmd += "--include_source_info"
       }
     }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -31,26 +31,15 @@
 package com.google.protobuf.gradle
 
 import com.google.common.collect.ImmutableList
-import org.apache.commons.lang.StringUtils
-import org.gradle.api.Action
-import org.gradle.api.file.ConfigurableFileTree
-import org.gradle.api.file.SourceDirectorySet
+
 import org.gradle.api.GradleException
-import org.gradle.api.internal.file.DefaultSourceDirectorySet
-import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.plugins.DslObject
-import org.gradle.api.internal.tasks.DefaultSourceSet
-import org.gradle.api.InvalidUserDataException
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.Plugin
-import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.tooling.UnsupportedVersionException
-import org.gradle.util.CollectionUtils
 
 import javax.inject.Inject
 


### PR DESCRIPTION
- `descriptorSetPath` allows to put the descriptor in a different location than the generated Java. This is useful if the generated Java should be in the src folder.
- `includeSourceInfoInDescriptorSet` and `includeImportsInDescriptorSet` allow to control the according protoc options.
- As a side effect, Eclipse found some unused imports which I suggest to fix with this commit as well.