### PR TITLE
Allow protos in test to import protos in main

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -44,11 +44,6 @@ class ProtobufExtract extends DefaultTask {
    */
   private File destDir
 
-  /**
-   * The name of the configuration that contains proto files.
-   */
-  private String configName
-
   protected void setDestDir(File destDir) {
     Preconditions.checkState(this.destDir == null, 'destDir already set')
     this.destDir = destDir
@@ -59,24 +54,19 @@ class ProtobufExtract extends DefaultTask {
     return destDir
   }
 
-  protected void setConfigName(String configName) {
-    Preconditions.checkState(this.configName == null, 'configName already set')
-    this.configName = configName
-    def config = project.configurations[configName]
-    inputs.files config
-    dependsOn config
-  }
-
-  protected String getConfigName() {
-    return configName
-  }
-
   @TaskAction
   def extract() {
-    logger.debug "Extracting protos from configuration ${configName} to ${destDir}"
     inputs.files.each { file ->
       logger.debug "Extracting protos from ${file} to ${destDir}"
-      if (file.path.endsWith('.proto')) {
+      if (file.isDirectory()) {
+        project.copy {
+          includeEmptyDirs(false)
+          from(file.path) {
+            include '**/*.proto'
+          }
+          into(destDir)
+        }
+      } else if (file.path.endsWith('.proto')) {
         project.copy {
           includeEmptyDirs(false)
           from(file.path)

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -322,7 +322,7 @@ class ProtobufPlugin implements Plugin<Project> {
       return project.tasks.create(extractProtosTaskName, ProtobufExtract) {
         description = "Extracts proto files/dependencies specified by 'protobuf' configuration"
         destDir = getExtractedProtosDir(sourceSetName) as File
-        configName = Utils.getConfigName(sourceSetName, 'protobuf')
+        inputs.files project.configurations[Utils.getConfigName(sourceSetName, 'protobuf')]
       }
     }
 
@@ -346,7 +346,27 @@ class ProtobufPlugin implements Plugin<Project> {
       return project.tasks.create(extractIncludeProtosTaskName, ProtobufExtract) {
         description = "Extracts proto files from compile dependencies for includes"
         destDir = getExtractedIncludeProtosDir(sourceSetName) as File
-        configName = Utils.getConfigName(sourceSetName, 'compile')
+        inputs.files project.configurations[Utils.getConfigName(sourceSetName, 'compile')]
+
+        // TL; DR: Make protos in 'test' sourceSet able to import protos from the 'main' sourceSet.
+        // Sub-configurations, e.g., 'testCompile' that extends 'compile', don't depend on the
+        // their super configurations. As a result, 'testCompile' doesn't depend on 'compile' and
+        // it cannot get the proto files from 'main' sourceSet through the configuration. However,
+	if (Utils.isAndroidProject(project)) {
+          // TODO(zhangkun83): Android sourceSet doesn't have compileClasspath. If it did, we
+          // haven't figured out a way to put source protos in 'resources'. For now we use an ad-hoc
+          // solution that manually includes the source protos of 'main' and its dependencies.
+          if (sourceSetName == 'androidTest') {
+            inputs.files getSourceSets()['main'].proto
+            inputs.files project.configurations['compile']
+          }
+        } else {
+          // In Java projects, the compileClasspath of the 'test' sourceSet includes all the
+          // 'resources' of the output of 'main', in which the source protos are placed.
+          // This is nicer than the ad-hoc solution that Android has, because it works for any
+          // extended configuration, not just 'testCompile'.
+          inputs.files getSourceSets()[sourceSetName].compileClasspath
+	}
       }
     }
 

--- a/testProject/src/test/proto/test.proto
+++ b/testProject/src/test/proto/test.proto
@@ -1,4 +1,8 @@
 syntax = "proto3";
 
+// From the main sourceSet
+import "com/example/tutorial/sample.proto";
+
 message MsgTest {
+  Msg msg = 1;
 }

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.3.1'
         classpath 'junit:junit:4.7'
     }
 }

--- a/testProjectAndroid/src/androidTest/proto/sample.proto
+++ b/testProjectAndroid/src/androidTest/proto/sample.proto
@@ -4,6 +4,8 @@ option java_package = "com.example.tutorial";
 option java_outer_classname = "OuterSample";
 option java_multiple_files = true;
 
+// From the main sourceSet
+import "helloworld.proto";
 
 message Msg {
     string foo = 1;
@@ -12,4 +14,5 @@ message Msg {
 
 message SecondMsg {
     int32 blah = 1;
+    helloworld.HelloReply reply = 2;
 }

--- a/testProjectDependent/build.gradle
+++ b/testProjectDependent/build.gradle
@@ -20,7 +20,7 @@ protobuf.protoc {
 test.doLast {
   // This project has compiled only one proto file, despite that it imports
   // other proto files from dependencies.
-  def generatedFiles = project.fileTree(protobuf.generatedFilesBaseDir)
+  def generatedFiles = project.fileTree(protobuf.generatedFilesBaseDir + "/main")
   File onlyGeneratedFile = generatedFiles.singleFile
   org.junit.Assert.assertEquals('Dependent.java', onlyGeneratedFile.name)
 }

--- a/testProjectDependent/src/main/proto/dependent.proto
+++ b/testProjectDependent/src/main/proto/dependent.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package dependent;
+
 // From testProject/src/main/proto
 import "ws/antonov/protobuf/test/test.proto";
 

--- a/testProjectDependent/src/test/java/DependentTest.java
+++ b/testProjectDependent/src/test/java/DependentTest.java
@@ -5,12 +5,15 @@ import org.junit.Test;
 public class DependentTest {
 
   @Test public void testProtos() {
-    Dependent.WrapperMessage message =
-        Dependent.WrapperMessage.newBuilder()
+    dependent.Dependent.WrapperMessage message =
+        dependent.Dependent.WrapperMessage.newBuilder()
             .setItem(ws.antonov.protobuf.test.Test.Item.getDefaultInstance())
             .setAny(com.google.protobuf.Any.getDefaultInstance())
             .build();
     assertSame(ws.antonov.protobuf.test.Test.Item.getDefaultInstance(),
         message.getItem());
+    Dependent2.TestWrapperMessage testMessage =
+        Dependent2.TestWrapperMessage.newBuilder()
+            .setM(message).build();
   }
 }

--- a/testProjectDependent/src/test/proto/dependent2.proto
+++ b/testProjectDependent/src/test/proto/dependent2.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+// From the 'main' sourceSet
+import "dependent.proto";
+
+message TestWrapperMessage {
+  dependent.WrapperMessage m = 1;
+}


### PR DESCRIPTION
Resolves #58 

In Java projects, an `extractInclude*Proto` task will include files under the `compileClasspath` of the corresponding source set. For example, `extractIncludeTestProto` task will include the `compileClasspath` of the `test` source set, which has the protos from `main` source set.

In Android projects, the classpath trick doesn't work. Instead, we make `extractIncludeAndroidTestProto` task include the protos of the `main` source set, as well as the dependencies of its configuration, which is `compile`.