### PR TITLE
Plugin throws NPE on non-Android Gradle projects in IntelliJ

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -52,6 +52,6 @@ class Utils {
   }
 
   static boolean isAndroidProject(Project project) {
-    return project.hasProperty('android')
+    return project.hasProperty('android') && project.android.sourceSets
   }
 }


### PR DESCRIPTION
Currently, all non-Android Gradle projects in IntelliJ where the Android Support plugin is present fail project configuration with an NPE.

IntelliJ's Android Support plugin adds the 'android' project property even for non-Android Gradle projects, so `Utils.isAndroidProject(project)` is not a completely accurate signal in its own right. 

The solution is simply to fall back on `project.sourceSets` if necessary.

Current workaround is to remove Android Support from IntelliJ.