### PR TITLE
Add output dirs of generateProtoTask to sourceSet.java for Java project

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -385,7 +385,7 @@ class ProtobufPlugin implements Plugin<Project> {
           project.protobuf.generateProtoTasks.ofSourceSet(sourceSet.name).each { generateProtoTask ->
             javaCompileTask.dependsOn(generateProtoTask)
             generateProtoTask.getAllOutputDirs().each { dir ->
-              javaCompileTask.source project.fileTree(dir: dir)
+              sourceSet.java.srcDir dir
             }
           }
         }


### PR DESCRIPTION
add output dirs of generateProtoTask to corresponding sourceSet's [Java SourceDirectorySet][javasource]

* IDE can import generated source directories automatically(test with IntelliJ IDEA Community Edition 2016.1)
* the generated classes are included in the output of javadoc task
* I think this is a more public API

[javasource]: https://docs.gradle.org/2.12/javadoc/org/gradle/api/tasks/SourceSet.html#getJava() " sourceSet.java"
