### PR TITLE
Reduce memory and CPU usage for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ android:
   licenses:
     - '.+'
 
+env:
+  global:
+    - GRADLE_OPTS="-Xmx128m"
+
 script:
   - ./gradlew clean assemble test --stacktrace
 

--- a/build.gradle
+++ b/build.gradle
@@ -173,3 +173,18 @@ task checkJavaVersion << {
   }
 }
 [uploadArchives, publishPlugins]*.dependsOn checkJavaVersion
+
+// To limit the memory usage when running in Travis.
+// Travis tend to kill tasks that use too much memory.
+if (System.env.TRAVIS == 'true') {
+  allprojects {
+    tasks.withType(GroovyCompile) {
+      groovyOptions.fork = false
+    }
+    tasks.withType(Test) {
+      // containers (currently) have 2 dedicated cores and 4GB of memory
+      maxParallelForks = 2
+      minHeapSize = '128m'
+    }
+  }
+}


### PR DESCRIPTION
Travis tends to kill tasks that use too much memory or CPU.
Reference: https://discuss.gradle.org/t/travis-ci-org-gradle-launcher-daemon-client-daemondisappearedexception-gradle-build-daemon-disappeared-unexpectedly-it-may-have-been-killed-or-may-have-crashed/13106/3