### PR TITLE
Stop using a deprecated API on Gradle 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ android:
 
 env:
   global:
-    - GRADLE_OPTS="-Xmx128m"
+    - GRADLE_OPTS="-Xms128m"
 
 script:
-  - ./gradlew clean assemble test --stacktrace
+  - ./gradlew clean assemble test --tests com.google.protobuf.gradle.plugins.ProtobufJavaPluginTest --stacktrace
+  - ./gradlew test --tests com.google.protobuf.gradle.plugins.ProtobufAndroidPluginTest --stacktrace
+
 
 notifications:
   email: false

--- a/build.gradle
+++ b/build.gradle
@@ -175,9 +175,9 @@ task checkJavaVersion << {
 }
 [uploadArchives, publishPlugins]*.dependsOn checkJavaVersion
 
-// To limit the memory usage when running in Travis.
-// Travis tend to kill tasks that use too much memory.
 if (System.env.TRAVIS == 'true') {
+  // To limit the memory usage when running in Travis.
+  // Travis tend to kill tasks that use too much memory.
   allprojects {
     tasks.withType(GroovyCompile) {
       groovyOptions.fork = false
@@ -188,4 +188,12 @@ if (System.env.TRAVIS == 'true') {
       minHeapSize = '128m'
     }
   }
+  // The Android test takes longer than 10 minutes.  Travis kills the test if it has
+  // seen no output for 10 minutes, so we need to produced output.
+  test {
+    testLogging {
+      showStandardStreams = true
+    }
+  }
 }
+

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -268,7 +268,7 @@ class ProtobufPlugin implements Plugin<Project> {
         outputBaseDir = "${project.protobuf.generatedFilesBaseDir}/${sourceSetOrVariantName}"
         sourceSets.each { sourceSet ->
           // Include sources
-          inputs.source sourceSet.proto
+          Utils.addFilesToTaskInputs(project, inputs, sourceSet.proto)
           ProtobufSourceDirectorySet protoSrcDirSet = sourceSet.proto
           protoSrcDirSet.srcDirs.each { srcDir ->
             include srcDir
@@ -279,7 +279,7 @@ class ProtobufPlugin implements Plugin<Project> {
               project.fileTree(getExtractedProtosDir(sourceSet.name)) {
                 include "**/*.proto"
               }
-          inputs.source extractedProtoSources
+          Utils.addFilesToTaskInputs(project, inputs, extractedProtoSources)
           include extractedProtoSources.dir
 
           // Register extracted include protos

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -19,9 +19,15 @@ class ProtobufAndroidPluginTest extends Specification {
     def result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
       .withArguments('testProjectAndroid:build')
+      .withGradleVersion(gradleVersion)
+      .forwardStdOutput(new OutputStreamWriter(System.out))
+      .forwardStdError(new OutputStreamWriter(System.err))
       .build()
 
     then: "it succeed"
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
+
+    where:
+    gradleVersion << ["2.14.1", "3.0"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -9,6 +9,8 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
 
 class ProtobufJavaPluginTest extends Specification {
+  private static final def gradleVersions = ["2.12", "3.0"]
+
   private Project setupBasicProject() {
     Project project = ProjectBuilder.builder().build()
     project.apply plugin: 'java'
@@ -59,6 +61,7 @@ class ProtobufJavaPluginTest extends Specification {
     def result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build')
+      .withGradleVersion(gradleVersion)
       .build()
 
     then: "it succeed"
@@ -73,6 +76,9 @@ class ProtobufJavaPluginTest extends Specification {
       }
       assert fileList.size > 0
     }
+
+    where:
+    gradleVersion << gradleVersions
   }
 
   def "testProjectLite should be successfully executed"() {
@@ -84,10 +90,14 @@ class ProtobufJavaPluginTest extends Specification {
     def result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build')
+      .withGradleVersion(gradleVersion)
       .build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
+
+    where:
+    gradleVersion << gradleVersions
   }
 
   def "testProjectDependent should be successfully executed"() {
@@ -99,10 +109,14 @@ class ProtobufJavaPluginTest extends Specification {
     def result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
       .withArguments('testProjectDependent:build')
+      .withGradleVersion(gradleVersion)
       .build()
 
     then: "it succeed"
     result.task(":testProjectDependent:build").outcome == TaskOutcome.SUCCESS
+
+    where:
+    gradleVersion << gradleVersions
   }
 
   def "testProjectCustomProtoDir should be successfully executed"() {
@@ -114,9 +128,13 @@ class ProtobufJavaPluginTest extends Specification {
     def result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build')
+      .withGradleVersion(gradleVersion)
       .build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
+
+    where:
+    gradleVersion << gradleVersions
   }
 }


### PR DESCRIPTION
Resolves #98 

Also make tests to run with the minimum (2.12) and the maximum (3.0) supported Gradle versions, except for Android tests which require 2.14.1 as required by the Android plugin used.