### PR TITLE
[docs] FIx IDEA hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,15 @@ can include the following block in you `build.gradle` to ask IntelliJ
 to include the generated Java directories as source folders.
 
 ```gradle
+protobuf {
+    ...
+    generatedFilesBaseDir = "$projectDir/gen"
+}
+
+clean {
+    delete protobuf.generatedFilesBaseDir
+}
+
 idea {
     module {
         sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/java");


### PR DESCRIPTION
It looks like that a folder under an excluded one ( buildDir ) cannot be used as source.

I've notified this [issue on the gradle forums](https://discuss.gradle.org/t/idea-module-generatedsourcedirs-broken-for-multiple-projects/20291).

Thank you for your work :blush:
