### PR TITLE
Ensure reproducible output from generate task

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -361,7 +361,8 @@ public class GenerateProtoTask extends DefaultTask {
     Preconditions.checkState(state == State.FINALIZED, 'doneConfig() has not been called')
 
     ToolsLocator tools = project.protobuf.tools
-    Set<File> protoFiles = inputs.sourceFiles.files
+    // Sort to make sure files are in a consistent order
+    List<File> protoFiles = inputs.sourceFiles.files.sort()
 
     [builtins, plugins]*.each { plugin ->
       File outputDir = new File(getOutputDir(plugin))

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -361,7 +361,8 @@ public class GenerateProtoTask extends DefaultTask {
     Preconditions.checkState(state == State.FINALIZED, 'doneConfig() has not been called')
 
     ToolsLocator tools = project.protobuf.tools
-    // Sort to make sure files are in a consistent order
+    // Sort to ensure generated descriptors have a canonical representation
+    // to avoid triggering unnecessary rebuilds downstream
     List<File> protoFiles = inputs.sourceFiles.files.sort()
 
     [builtins, plugins]*.each { plugin ->


### PR DESCRIPTION
## Expected behavior

`GenerateProtoTask` should generate the exact same output from the same inputs.

## Current behavior

`GenerateProtoTask` generate slightly different output when the order of the input files is different. This will prevent tasks depending on the output of the `GenerateProtoTask` to be marked as `UP-TO-DATE`.
