### PR TITLE
Update for Android Gradle plugin  2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: android
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-26.0.0
+    - build-tools-26.0.1
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: android
 
 jdk:
@@ -29,7 +27,7 @@ script:
 notifications:
   email: false
 
-sudo: false
+sudo: required
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-23.0.3
-    - android-23
+    - build-tools-26.0.0
+    - android-26
     - extra-android-support
     - extra-android-m2repository
   licenses:

--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,10 @@ if (System.env.TRAVIS == 'true') {
   test {
     testLogging {
       showStandardStreams = true
+      exceptionFormat = 'full'
+      showExceptions true
+      showCauses true
+      showStackTraces true
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ pluginBundle {
 // Releases must be built on Java 1.7. Building on Java 1.8 will make the
 // plugin runnable only on Java 1.8.
 // See https://github.com/grpc/grpc-java/issues/805
-task checkJavaVersion << {
+tasks.create("checkJavaVersion").doLast {
   JavaVersion javaVersion = JavaVersion.current()
   if (!javaVersion.isJava7()) {
     throw new GradleException(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -37,7 +37,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
@@ -261,7 +260,7 @@ class ProtobufPlugin implements Plugin<Project> {
       } else {
         // For Android Gradle plugin < 2.5
         sourceSetNames.each { sourceSetName ->
-          def extractIncludeProtosTask =
+          Task extractIncludeProtosTask =
               maybeAddExtractIncludeProtosTask(sourceSetName)
           generateProtoTask.dependsOn(extractIncludeProtosTask)
         }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -37,7 +37,10 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.tasks.SourceSet
@@ -241,9 +244,26 @@ class ProtobufPlugin implements Plugin<Project> {
       sourceSetNames.each { sourceSetName ->
         def extractProtosTask = maybeAddExtractProtosTask(sourceSetName)
         generateProtoTask.dependsOn(extractProtosTask)
+      }
 
-        def extractIncludeProtosTask = maybeAddExtractIncludeProtosTask(sourceSetName)
+      // Extract proto file from the compile classpath configuration exposed in Android Gradle plugin 2.5.  Revert to
+      // original behavior if the configuration is not found.
+      if (variant.hasProperty("compileConfiguration")) {
+        def artifactType = Attribute.of("artifactType", String)
+        def extractIncludeProtosTask =
+            maybeAddExtractIncludeProtosTask(
+                    variant.name,
+                    variant.compileConfiguration.incoming.artifactView{ attributes{ it.attribute(artifactType, "jar") }}.files,
+                    variant.hasProperty("testedVariant") ?
+                            variant.testedVariant.compileConfiguration.incoming.artifactView{ attributes{ it.attribute(artifactType, "jar") }}.files :
+                            null)
         generateProtoTask.dependsOn(extractIncludeProtosTask)
+      } else {
+        sourceSetNames.each { sourceSetName ->
+          def extractIncludeProtosTask =
+              maybeAddExtractIncludeProtosTask(sourceSetName)
+          generateProtoTask.dependsOn(extractIncludeProtosTask)
+        }
       }
 
       // TODO(zhangkun83): Include source proto files in the compiled archive,
@@ -324,41 +344,43 @@ class ProtobufPlugin implements Plugin<Project> {
      * they won't be compiled since they have already been compiled in their
      * own projects or artifacts.
      *
-     * <p>This task is per-sourceSet, for both Java and Android. In Android a
-     * variant may have multiple sourceSets, each of these sourceSets will have
-     * its own extraction task.
+     * <p>This task is per-sourceSet for both Java and per variant for Android.
      */
-    private Task maybeAddExtractIncludeProtosTask(String sourceSetName) {
+    private Task maybeAddExtractIncludeProtosTask(
+        String sourceSetOrVariantName,
+        FileCollection compileClasspathConfiguration = null,
+        FileCollection testedCompileClasspathConfiguration = null) {
       def extractIncludeProtosTaskName = 'extractInclude' +
-          Utils.getSourceSetSubstringForTaskNames(sourceSetName) + 'Proto'
+          Utils.getSourceSetSubstringForTaskNames(sourceSetOrVariantName) + 'Proto'
       Task existingTask = project.tasks.findByName(extractIncludeProtosTaskName)
       if (existingTask != null) {
         return existingTask
       }
       return project.tasks.create(extractIncludeProtosTaskName, ProtobufExtract) {
         description = "Extracts proto files from compile dependencies for includes"
-        destDir = getExtractedIncludeProtosDir(sourceSetName) as File
-        inputs.files project.configurations[Utils.getConfigName(sourceSetName, 'compile')]
+        destDir = getExtractedIncludeProtosDir(sourceSetOrVariantName) as File
+        inputs.files compileClasspathConfiguration ?:
+            project.configurations[Utils.getConfigName(sourceSetOrVariantName, 'compile')]
 
         // TL; DR: Make protos in 'test' sourceSet able to import protos from the 'main' sourceSet.
         // Sub-configurations, e.g., 'testCompile' that extends 'compile', don't depend on the
         // their super configurations. As a result, 'testCompile' doesn't depend on 'compile' and
         // it cannot get the proto files from 'main' sourceSet through the configuration. However,
-	if (Utils.isAndroidProject(project)) {
+        if (Utils.isAndroidProject(project)) {
           // TODO(zhangkun83): Android sourceSet doesn't have compileClasspath. If it did, we
           // haven't figured out a way to put source protos in 'resources'. For now we use an ad-hoc
           // solution that manually includes the source protos of 'main' and its dependencies.
-          if (sourceSetName == 'androidTest') {
+          if (sourceSetOrVariantName.toLowerCase().contains('androidtest')) {
             inputs.files getSourceSets()['main'].proto
-            inputs.files project.configurations['compile']
+            inputs.files testedCompileClasspathConfiguration ?: project.configurations['compile']
           }
         } else {
           // In Java projects, the compileClasspath of the 'test' sourceSet includes all the
           // 'resources' of the output of 'main', in which the source protos are placed.
           // This is nicer than the ad-hoc solution that Android has, because it works for any
           // extended configuration, not just 'testCompile'.
-          inputs.files getSourceSets()[sourceSetName].compileClasspath
-	}
+          inputs.files getSourceSets()[sourceSetOrVariantName].compileClasspath
+        }
       }
     }
 

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -246,9 +246,8 @@ class ProtobufPlugin implements Plugin<Project> {
         generateProtoTask.dependsOn(extractProtosTask)
       }
 
-      // Extract proto file from the compile classpath configuration exposed in Android Gradle plugin 2.5.  Revert to
-      // original behavior if the configuration is not found.
       if (variant.hasProperty("compileConfiguration")) {
+        // For Android Gradle plugin >= 2.5
         def artifactType = Attribute.of("artifactType", String)
         def extractIncludeProtosTask =
             maybeAddExtractIncludeProtosTask(
@@ -259,6 +258,7 @@ class ProtobufPlugin implements Plugin<Project> {
                             null)
         generateProtoTask.dependsOn(extractIncludeProtosTask)
       } else {
+        // For Android Gradle plugin < 2.5
         sourceSetNames.each { sourceSetName ->
           def extractIncludeProtosTask =
               maybeAddExtractIncludeProtosTask(sourceSetName)

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -20,6 +20,7 @@ class ProtobufAndroidPluginTest extends Specification {
       .withProjectDir(mainProjectDir)
       .withArguments(
               "-DANDROID_PLUGIN_VERSION=${androidPluginVersion}", 
+              "-Pandroid.buildCacheDir=" + new File(mainProjectDir, ".buildCache"), // set android build cache to avoid using home directory on travis CI.
               'testProjectAndroid:build')
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -15,6 +15,23 @@ class ProtobufAndroidPluginTest extends Specification {
     def mainProjectDir = ProtobufPluginTestHelper.prepareTestTempDir('testProjectAndroid')
     ProtobufPluginTestHelper.copyTestProjects(mainProjectDir, 'testProject', 'testProjectLite', 'testProjectAndroid')
 
+    // Add android plugin to the test root project so that Gradle an resolve
+    // classpath correctly.
+    new File(mainProjectDir, "build.gradle") << """
+buildscript {
+    def androidPluginVersion = System.properties.get("ANDROID_PLUGIN_VERSION") ?: "2.2.0"
+    repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
+        if (androidPluginVersion.startsWith("3.")) {
+            google()
+        }
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:$androidPluginVersion"
+    }
+}
+"""
+
     when: "build is invoked"
     def result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
@@ -31,7 +48,7 @@ class ProtobufAndroidPluginTest extends Specification {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ["2.2.0-beta1", "2.2.0-beta1", "3.0.0-alpha4"]
-    gradleVersion << ["2.14.1", "3.0", "4.0"]
+    androidPluginVersion << ["2.2.0", "2.2.0", "3.0.0-alpha6"]
+    gradleVersion << ["2.14.1", "3.0", "4.1-milestone-1"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -18,7 +18,9 @@ class ProtobufAndroidPluginTest extends Specification {
     when: "build is invoked"
     def result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
-      .withArguments('testProjectAndroid:build')
+      .withArguments(
+              "-DANDROID_PLUGIN_VERSION=${androidPluginVersion}", 
+              'testProjectAndroid:build')
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
@@ -28,6 +30,7 @@ class ProtobufAndroidPluginTest extends Specification {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    gradleVersion << ["2.14.1", "3.0"]
+    androidPluginVersion << ["2.2.0-beta1", "2.2.0-beta1", "3.0.0-alpha4"]
+    gradleVersion << ["2.14.1", "3.0", "4.0"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -20,7 +20,7 @@ class ProtobufAndroidPluginTest extends Specification {
     // classpath correctly.
     new File(mainProjectDir, "build.gradle") << """
 buildscript {
-    def androidPluginVersion = System.properties.get("ANDROID_PLUGIN_VERSION") ?: "2.2.0"
+    String androidPluginVersion = System.properties.get("ANDROID_PLUGIN_VERSION") ?: "2.2.0"
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
         if (androidPluginVersion.startsWith("3.")) {

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -38,7 +38,8 @@ buildscript {
       .withArguments(
               "-DANDROID_PLUGIN_VERSION=${androidPluginVersion}", 
               "-Pandroid.buildCacheDir=" + new File(mainProjectDir, ".buildCache"), // set android build cache to avoid using home directory on travis CI.
-              'testProjectAndroid:build')
+              "testProjectAndroid:build",
+              "--stacktrace")
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -32,6 +32,9 @@ buildscript {
 }
 """
 
+    new File(mainProjectDir, "gradle.properties") << """org.gradle.jvmargs=-Xmx1536m"""
+
+
     when: "build is invoked"
     def result = GradleRunner.create()
       .withProjectDir(mainProjectDir)

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -34,11 +34,15 @@ buildscript {
 """
 
     when: "build is invoked"
+    File localBuildCache = new File(mainProjectDir, ".buildCache")
+    if (localBuildCache.exists()) {
+        localBuildCache.deleteDir()
+    }
     BuildResult result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
       .withArguments(
               "-DANDROID_PLUGIN_VERSION=${androidPluginVersion}", 
-              "-Pandroid.buildCacheDir=" + new File(mainProjectDir, ".buildCache"), // set android build cache to avoid using home directory on travis CI.
+              "-Pandroid.buildCacheDir=" + localBuildCache, // set android build cache to avoid using home directory on travis CI.
               "testProjectAndroid:build",
               "--stacktrace")
       .withGradleVersion(gradleVersion)

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -27,7 +27,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$androidPluginVersion"
+        classpath "com.android.tools.build:gradle:\$androidPluginVersion"
     }
 }
 """

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -33,9 +33,6 @@ buildscript {
 }
 """
 
-    new File(mainProjectDir, "gradle.properties") << """org.gradle.jvmargs=-Xmx1536m"""
-
-
     when: "build is invoked"
     BuildResult result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
@@ -53,7 +50,7 @@ buildscript {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ["2.2.0", "2.2.0", "3.0.0-alpha6"]
+    androidPluginVersion << ["2.2.0", "2.2.0", "3.0.0-alpha7"]
     gradleVersion << ["2.14.1", "3.0", "4.1-milestone-1"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -15,7 +15,7 @@ class ProtobufAndroidPluginTest extends Specification {
     def mainProjectDir = ProtobufPluginTestHelper.prepareTestTempDir('testProjectAndroid')
     ProtobufPluginTestHelper.copyTestProjects(mainProjectDir, 'testProject', 'testProjectLite', 'testProjectAndroid')
 
-    // Add android plugin to the test root project so that Gradle an resolve
+    // Add android plugin to the test root project so that Gradle can resolve
     // classpath correctly.
     new File(mainProjectDir, "build.gradle") << """
 buildscript {

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -9,7 +9,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
 
 class ProtobufJavaPluginTest extends Specification {
-  private static final def gradleVersions = ["2.12", "3.0"]
+  private static final def gradleVersions = ["2.12", "3.0", "4.0"]
 
   private Project setupBasicProject() {
     Project project = ProjectBuilder.builder().build()

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -9,7 +9,7 @@ repositories {
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -62,6 +62,7 @@ android {
     }
 
     dexOptions {
+        javaMaxHeapSize "1g"
         threadCount 1 // reduce predex thread count to limit memory usage
     }
 }

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -1,18 +1,5 @@
 // An Android application project.
 
-buildscript {
-    def androidPluginVersion = System.properties.get("ANDROID_PLUGIN_VERSION") ?: "2.2.0-beta1"
-    repositories {
-        maven { url "https://plugins.gradle.org/m2/" }
-        if (androidPluginVersion.startsWith("3.")) {
-            google()
-        }
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:$androidPluginVersion"
-    }
-}
-
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.protobuf'
 

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -62,7 +62,7 @@ android {
     }
 
     dexOptions {
-        threadCount 1 // reduce predex thread count to limit memory usage
+        preDexLibraries false
     }
 }
 

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.0"
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -60,6 +60,10 @@ android {
         warning 'InvalidPackage'
         abortOnError false
     }
+
+    dexOptions {
+        threadCount 1 // reduce predex thread count to limit memory usage
+    }
 }
 
 protobuf {

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -1,24 +1,28 @@
 // An Android application project.
 
-apply plugin: 'com.android.application'
-apply plugin: 'com.google.protobuf'
-
 buildscript {
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-beta1'
-    }
+    def androidPluginVersion = System.properties.get("ANDROID_PLUGIN_VERSION") ?: "2.2.0-beta1"
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
+        if (androidPluginVersion.startsWith("3.")) {
+            google()
+        }
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:$androidPluginVersion"
     }
 }
+
+apply plugin: 'com.android.application'
+apply plugin: 'com.google.protobuf'
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -62,7 +62,7 @@ android {
     }
 
     dexOptions {
-        preDexLibraries false
+        threadCount 1 // reduce predex thread count to limit memory usage
     }
 }
 


### PR DESCRIPTION
Use compileClasspath Configuration for each variant instead
of the compile Configuration for the source sets for the
extract include proto tasks.