### PR TITLE
added new generateDescriptorSetOnly to skip code generation

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -72,14 +72,6 @@ public class GenerateProtoTask extends DefaultTask {
   public boolean generateDescriptorSet
 
   /**
-   * If true, will skip all non-descriptor related options
-   *
-   * Default: false
-   */
-  public boolean generateDescriptorSetOnly
-
-
-  /**
    * Configuration object for descriptor generation details.
    */
   public class DescriptorSetOptions {
@@ -383,24 +375,22 @@ public class GenerateProtoTask extends DefaultTask {
     def cmd = [ tools.protoc.path ]
     cmd.addAll(dirs)
 
-    if (!generateDescriptorSetOnly) {
-      // Handle code generation built-ins
-      builtins.each { builtin ->
-        String outPrefix = makeOptionsPrefix(builtin.options)
-        cmd += "--${builtin.name}_out=${outPrefix}${getOutputDir(builtin)}"
-      }
+    // Handle code generation built-ins
+    builtins.each { builtin ->
+      String outPrefix = makeOptionsPrefix(builtin.options)
+      cmd += "--${builtin.name}_out=${outPrefix}${getOutputDir(builtin)}"
+    }
 
-      // Handle code generation plugins
-      plugins.each { plugin ->
-        String name = plugin.name
-        ExecutableLocator locator = tools.plugins.findByName(name)
-        if (locator == null) {
-          throw new GradleException("Codegen plugin ${name} not defined")
-        }
-        String pluginOutPrefix = makeOptionsPrefix(plugin.options)
-        cmd += "--${name}_out=${pluginOutPrefix}${getOutputDir(plugin)}"
-        cmd += "--plugin=protoc-gen-${name}=${locator.path}"
+    // Handle code generation plugins
+    plugins.each { plugin ->
+      String name = plugin.name
+      ExecutableLocator locator = tools.plugins.findByName(name)
+      if (locator == null) {
+        throw new GradleException("Codegen plugin ${name} not defined")
       }
+      String pluginOutPrefix = makeOptionsPrefix(plugin.options)
+      cmd += "--${name}_out=${pluginOutPrefix}${getOutputDir(plugin)}"
+      cmd += "--plugin=protoc-gen-${name}=${locator.path}"
     }
 
     if (generateDescriptorSet) {

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -137,4 +137,33 @@ class ProtobufJavaPluginTest extends Specification {
     where:
     gradleVersion << gradleVersions
   }
+
+  def "testProjectFileDescriptorOnly should be successfully executed"() {
+    given: "project from testProjectFileDescriptorOnly"
+    def projectDir = ProtobufPluginTestHelper.prepareTestTempDir('testProjectFileDescriptorOnly')
+    ProtobufPluginTestHelper.copyTestProject(projectDir, 'testProjectFileDescriptorOnly')
+
+    when: "build is invoked"
+    def result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments('build')
+            .withGradleVersion(gradleVersion)
+            .build()
+
+    then: "it succeed"
+    result.task(":build").outcome == TaskOutcome.SUCCESS
+    ['main'].each {
+      def generatedSrcDir = new File(projectDir.path, "build/generated/source/proto/$it")
+      def fileList = []
+      generatedSrcDir.eachFileRecurse { file ->
+        if (file.path.endsWith('.java')) {
+          fileList.add (file)
+        }
+      }
+      assert fileList.size == 0 : "there should be no *.java files in source/proto/$it"
+    }
+
+    where:
+    gradleVersion << gradleVersions
+  }
 }

--- a/testProjectFileDescriptorOnly/build.gradle
+++ b/testProjectFileDescriptorOnly/build.gradle
@@ -1,0 +1,33 @@
+// A Java project that demonstrates the generation of the DescriptorSet without sources
+
+apply plugin: 'java'
+apply plugin: 'com.google.protobuf'
+
+repositories {
+    maven { url "https://plugins.gradle.org/m2/" }
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
+
+def protocVersion = '3.0.0'
+def protobufDep = "com.google.protobuf:protobuf-java:$protocVersion"
+
+dependencies {
+    compile protobufDep
+    testCompile 'junit:junit:4.12'
+}
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.0.0'
+    }
+    generateProtoTasks {
+        ofSourceSet('main').each { task ->
+            task.builtins {
+                remove java
+            }
+            task.generateDescriptorSet = true
+        }
+    }
+}

--- a/testProjectFileDescriptorOnly/src/main/proto/com/example/tutorial/sample.proto
+++ b/testProjectFileDescriptorOnly/src/main/proto/com/example/tutorial/sample.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+option java_package = "com.example.tutorial";
+option java_outer_classname = "OuterSample";
+option java_multiple_files = true;
+
+
+message Msg {
+    optional string foo = 1;
+    optional SecondMsg blah = 2;
+}
+
+message SecondMsg {
+    optional int32 blah = 1;
+}

--- a/testProjectFileDescriptorOnly/src/main/proto/ws/antonov/protobuf/test/test.proto
+++ b/testProjectFileDescriptorOnly/src/main/proto/ws/antonov/protobuf/test/test.proto
@@ -1,0 +1,29 @@
+syntax = "proto2";
+
+package ws.antonov.protobuf.test;
+
+import "com/example/tutorial/sample.proto";
+
+message TestMessage {
+  optional int32 id = 1;
+  optional string name = 2;
+}
+
+message AnotherMessage {
+  repeated string names = 1;
+  optional DataPayload data = 2;
+
+  message DataPayload {
+    optional string payload = 1;
+  }
+}
+
+message Item {
+  optional string name = 1;
+  optional string value = 2;
+  optional Msg msg = 3;
+  optional SecondMsg msg2 = 4;
+}
+message DataMap {
+  repeated Item data_items = 1;
+}


### PR DESCRIPTION
protoc allows for the creation of FileDescriptorSet without the actual code generation. This could be accomplished by not specifying any cmd options like --java_out. 
Unfortunately, this capability is absent in the plugin - the --<plugin name>_out is required.

This new boolean generateDescriptorSetOnly config property allows to skip any code generation but FileDescriptorSet. The implementation is minimal on purpose and doesn't pose any danger.
