### PR TITLE
Allow non-C++ implementations of the codegen plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ protobuf {
 }
 ```
 
+The syntax for `artifact` follows [Artifact Classifiers](https://docs.gradle.org/3.3/userguide/dependency_management.html#sub:classifiers)
+where the default classifier is `os.detector.classifier` (ie 
+`"${os.detector.os}-${os.detector.arch}"`) and the default extension is `"exe"`.
+Non-C++ implementations of codegen plugins can be used if a constant 
+`classifier` is specified (eg `"com.example:example-generator:1.0.0:-jvm8_32"`). 
+
 #### Customize code generation tasks
 
 The Protobuf plugin generates a task for each ``protoc`` run, which is for a

--- a/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
@@ -79,13 +79,13 @@ class ToolsLocator {
       transitive = false
       extendsFrom = []
     }
-    def groupId, artifact, version
-    (groupId, artifact, version) = locator.artifact.split(":")
+    def groupId, artifact, version, classifier, extension
+    (groupId, artifact, version, classifier, extension) = artifactParts(locator.artifact)
     def notation = [group: groupId,
                     name: artifact,
                     version: version,
-                    classifier: project.osdetector.classifier,
-                    ext: 'exe']
+                    classifier: classifier ?: project.osdetector.classifier,
+                    ext: extension ?: 'exe']
     Dependency dep = project.dependencies.add(config.name, notation)
 
     for (GenerateProtoTask protoTask in protoTasks) {
@@ -106,5 +106,12 @@ class ToolsLocator {
         }
       }
     }
+  }
+
+  static List<String> artifactParts(String artifact) {
+    ((artifact =~ /([+-0-9A-Z_a-z]+):([+-0-9A-Z_a-z]+):([+-0-9A-Z_a-z]+)(:[+-0-9A-Z_a-z]+)?(@[+-0-9A-Z_a-z]+)?/)[0]
+        .tail().collect {
+          it?.replaceFirst(/^[:@]/, '')
+        })
   }
 }

--- a/src/test/groovy/com/google/protobuf/gradle/ToolsLocatorSpec.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ToolsLocatorSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.protobuf.gradle
+
+import spock.lang.Specification
+
+class ToolsLocatorSpec extends Specification {
+  def '`classifier` and `extension` should both be `null`'() {
+    given:
+    final input = 'group:name:version'
+
+    expect:
+    ['group', 'name', 'version', null, null] == ToolsLocator.artifactParts(input)
+  }
+
+  def '`classifier` should be parsed and `extension` should be null'() {
+    given:
+    final input = 'group:name:version:classifier'
+
+    expect:
+    ['group', 'name', 'version', 'classifier', null] == ToolsLocator.artifactParts(input)
+  }
+
+  def '`classifier` should be `null` and `extension` should be parsed'() {
+    given:
+    final input = 'group:name:version@extension'
+
+    expect:
+    ['group', 'name', 'version', null, 'extension'] == ToolsLocator.artifactParts(input)
+  }
+
+  def '`classifier` and `extension` should both be parsed'() {
+    given:
+    final input = 'group:name:version:classifier@extension'
+
+    expect:
+    ['group', 'name', 'version', 'classifier', 'extension'] == ToolsLocator.artifactParts(input)
+  }
+}


### PR DESCRIPTION
This is related to https://github.com/google/protobuf-gradle-plugin/issues/31.