### PR TITLE
 Fix codenarc rule: design

### DIFF
--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -34,6 +34,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <ruleset-ref path='rulesets/braces.xml'/>
   <ruleset-ref path='rulesets/concurrency.xml'/>
   <ruleset-ref path='rulesets/convention.xml'/>
+  <ruleset-ref path='rulesets/design.xml'>
+    <exclude name="Instanceof"/>
+    <exclude name="ImplementationAsType"/>
+  </ruleset-ref>
   <ruleset-ref path='rulesets/exceptions.xml'/>
   <ruleset-ref path='rulesets/generic.xml'/>
   <ruleset-ref path='rulesets/grails.xml'/>
@@ -46,7 +50,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <exclude name="CyclomaticComplexity"/>	
   </ruleset-ref>
 <!-- The following rules do not pass yet
-  <ruleset-ref path='rulesets/design.xml'/>
   <ruleset-ref path='rulesets/dry.xml'/>
   <ruleset-ref path='rulesets/groovyism.xml'/>
   <ruleset-ref path='rulesets/formatting.xml'>

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -69,7 +69,7 @@ public class GenerateProtoTask extends DefaultTask {
    *
    * Default: false
    */
-  public boolean generateDescriptorSet
+  boolean generateDescriptorSet
 
   /**
    * Configuration object for descriptor generation details.
@@ -81,24 +81,24 @@ public class GenerateProtoTask extends DefaultTask {
      *
      * Default: null
      */
-    public GString path
+    GString path
 
     /**
      * If true, source information (comments, locations) will be included in the descriptor set.
      *
      * Default: false
      */
-    public boolean includeSourceInfo
+    boolean includeSourceInfo
 
     /**
      * If true, imports are included in the descriptor set, such that it is self-containing.
      *
      * Default: false
      */
-    public boolean includeImports
+    boolean includeImports
   }
 
-  public final DescriptorSetOptions descriptorSetOptions = new DescriptorSetOptions();
+  final DescriptorSetOptions descriptorSetOptions = new DescriptorSetOptions()
 
   private static enum State {
     INIT, CONFIG, FINALIZED
@@ -272,7 +272,7 @@ public class GenerateProtoTask extends DefaultTask {
    * The container of command-line options for a protoc plugin or a built-in output.
    */
   public static class PluginOptions implements Named {
-    private final ArrayList<String> options = new ArrayList<String>()
+    private final List<String> options = new ArrayList<String>()
     private final String name
     private String outputSubDir
 

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
@@ -48,7 +48,7 @@ public class ProtobufConfigurator {
    * The base directory of generated files. The default is
    * "${project.buildDir}/generated/source/proto".
    */
-  public String generatedFilesBaseDir
+  String generatedFilesBaseDir
 
   public ProtobufConfigurator(Project project, FileResolver fileResolver) {
     this.project = project


### PR DESCRIPTION
Apparently in groovy, creating a property is preferred to public fields. When a member var is created with no modifier, groovy automatically creates a getter/setter for it, which makes it interop well the java bean standard.

Things with legit uses:
- InstanceOf: the places we use it are reasonable
- ImplementationAsType: This forces use to say `List foo = new ArrayList<Integer>()` rather than `ArrayList foo = new ArrayList<Integer>()`. This doesn't make much sense when we're talking about stuff with complex type hierarchies from libraries.