### PR TITLE
Fix codenarc rule: security

### DIFF
--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -48,6 +48,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <exclude name="JUnitTestMethodWithoutAssert"/>
   </ruleset-ref>
   <ruleset-ref path='rulesets/logging.xml'/>
+  <ruleset-ref path='rulesets/security.xml'>
+    <exclude name="JavaIoPackageAccess"/>
+  </ruleset-ref>
   <ruleset-ref path='rulesets/size.xml'>
     <!-- AbcMetric, CrapMetric and CyclomaticComplexity require external libs -->
     <exclude name="AbcMetric"/>
@@ -62,7 +65,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </rule-config>
   </ruleset-ref>
   <ruleset-ref path='rulesets/naming.xml'/>
-  <ruleset-ref path='rulesets/security.xml'/>
   <ruleset-ref path='rulesets/serialization.xml'/>
   <ruleset-ref path='rulesets/unnecessary.xml'/>
   <ruleset-ref path='rulesets/unused.xml'/>


### PR DESCRIPTION
Disabling JavaIoPackageAccess:
"This rule reports violations of the Enterprise JavaBeans specification by using the java.io package to access files or the file system."

We need java.io.* and don't care about the enterprise javabeans spec.

