### PR TITLE
Fix codenarc rule: naming

### DIFF
--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -49,6 +49,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <exclude name="JUnitTestMethodWithoutAssert"/>
   </ruleset-ref>
   <ruleset-ref path='rulesets/logging.xml'/>
+  <ruleset-ref path='rulesets/naming.xml'>
+    <exclude name="ConfusingMethodName"/>
+    <!-- unit tests have arbitrary names -->
+   <exclude name='MethodName'/>
+  </ruleset-ref>
   <ruleset-ref path='rulesets/security.xml'>
     <exclude name="JavaIoPackageAccess"/>
   </ruleset-ref>
@@ -62,7 +67,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <ruleset-ref path='rulesets/unused.xml'/>
 <!-- The following rules do not pass yet
   <ruleset-ref path='rulesets/dry.xml'/>
-  <ruleset-ref path='rulesets/naming.xml'/>
   <ruleset-ref path='rulesets/unnecessary.xml'/>
 -->
 </ruleset>

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -52,7 +52,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <ruleset-ref path='rulesets/naming.xml'>
     <exclude name="ConfusingMethodName"/>
     <!-- unit tests have arbitrary names -->
-   <exclude name='MethodName'/>
+    <exclude name='MethodName'/>
+    <exclude name='FactoryMethodName'/>
   </ruleset-ref>
   <ruleset-ref path='rulesets/security.xml'>
     <exclude name="JavaIoPackageAccess"/>

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -50,7 +50,7 @@ import javax.inject.Inject
  */
 class ProtobufPlugin implements Plugin<Project> {
     // any one of these plugins should be sufficient to proceed with applying this plugin
-    private static final List<String> prerequisitePluginOptions = [
+    private static final List<String> PREREQ_PLUGIN_OPTIONS = [
             'java',
             'com.android.application',
             'com.android.library',
@@ -86,7 +86,7 @@ class ProtobufPlugin implements Plugin<Project> {
           }
         }
 
-        prerequisitePluginOptions.each { pluginName ->
+        PREREQ_PLUGIN_OPTIONS.each { pluginName ->
           project.pluginManager.withPlugin(pluginName, applyWithPrerequisitePlugin)
         }
 

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Specification
  * Unit tests for normal java functionality.
  */
 class ProtobufJavaPluginTest extends Specification {
-  private static final List<String> gradleVersions = ["2.12", "3.0", "4.0"]
+  private static final List<String> GRADLE_VERSIONS = ["2.12", "3.0", "4.0"]
 
   private Project setupBasicProject() {
     Project project = ProjectBuilder.builder().build()
@@ -82,7 +82,7 @@ class ProtobufJavaPluginTest extends Specification {
     }
 
     where:
-    gradleVersion << gradleVersions
+    gradleVersion << GRADLE_VERSIONS
   }
 
   void "testProjectLite should be successfully executed"() {
@@ -101,7 +101,7 @@ class ProtobufJavaPluginTest extends Specification {
     result.task(":build").outcome == TaskOutcome.SUCCESS
 
     where:
-    gradleVersion << gradleVersions
+    gradleVersion << GRADLE_VERSIONS
   }
 
   void "testProjectDependent should be successfully executed"() {
@@ -120,7 +120,7 @@ class ProtobufJavaPluginTest extends Specification {
     result.task(":testProjectDependent:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    gradleVersion << gradleVersions
+    gradleVersion << GRADLE_VERSIONS
   }
 
   void "testProjectCustomProtoDir should be successfully executed"() {
@@ -139,6 +139,6 @@ class ProtobufJavaPluginTest extends Specification {
     result.task(":build").outcome == TaskOutcome.SUCCESS
 
     where:
-    gradleVersion << gradleVersions
+    gradleVersion << GRADLE_VERSIONS
   }
 }


### PR DESCRIPTION
Also fix a 120 character issue that slipped into the repo
Disable two naming rules because we already break them a lot in our repo and it's not worthwhile to fix them all:
- our test cases have spaces in their method names
- some of our method names are the same names as internal fields