### PR TITLE
tests: show stacktrace in stdout/stderr, always run in-process

### DIFF
--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -48,6 +48,7 @@ buildscript {
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
+      .withDebug(true)
       .build()
 
     then: "it succeed"

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -48,7 +48,6 @@ buildscript {
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
-      .withDebug(true)
       .build()
 
     then: "it succeed"

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -64,8 +64,11 @@ class ProtobufJavaPluginTest extends Specification {
     when: "build is invoked"
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
-      .withArguments('build')
+      .withArguments('build', '--stacktrace')
       .withGradleVersion(gradleVersion)
+      .forwardStdOutput(new OutputStreamWriter(System.out))
+      .forwardStdError(new OutputStreamWriter(System.err))
+      .withDebug(true)
       .build()
 
     then: "it succeed"
@@ -93,8 +96,11 @@ class ProtobufJavaPluginTest extends Specification {
     when: "build is invoked"
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
-      .withArguments('build')
+      .withArguments('build', '--stacktrace')
       .withGradleVersion(gradleVersion)
+      .forwardStdOutput(new OutputStreamWriter(System.out))
+      .forwardStdError(new OutputStreamWriter(System.err))
+      .withDebug(true)
       .build()
 
     then: "it succeed"
@@ -112,8 +118,11 @@ class ProtobufJavaPluginTest extends Specification {
     when: "build is invoked"
     BuildResult result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
-      .withArguments('testProjectDependent:build')
+      .withArguments('testProjectDependent:build', '--stacktrace')
       .withGradleVersion(gradleVersion)
+      .withDebug(true)
+      .forwardStdOutput(new OutputStreamWriter(System.out))
+      .forwardStdError(new OutputStreamWriter(System.err))
       .build()
 
     then: "it succeed"
@@ -131,8 +140,11 @@ class ProtobufJavaPluginTest extends Specification {
     when: "build is invoked"
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
-      .withArguments('build')
+      .withArguments('build', '--stacktrace')
       .withGradleVersion(gradleVersion)
+      .forwardStdOutput(new OutputStreamWriter(System.out))
+      .forwardStdError(new OutputStreamWriter(System.err))
+      .withDebug(true)
       .build()
 
     then: "it succeed"

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -120,9 +120,9 @@ class ProtobufJavaPluginTest extends Specification {
       .withProjectDir(mainProjectDir)
       .withArguments('testProjectDependent:build', '--stacktrace')
       .withGradleVersion(gradleVersion)
-      .withDebug(true)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
+      .withDebug(true)
       .build()
 
     then: "it succeed"


### PR DESCRIPTION
- Always run unit tests with `--stacktrace` and forward stdout/stderr,
  for more info about test failures
- Always run `withDebug(true)`, so that the gradle library runs in the
  same JVM as the unit test. This way break points work as expected.