### PR TITLE
Pass sourcesets using TaskInputs.files, not .file

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -63,7 +63,7 @@ class Utils {
 
   static void addFilesToTaskInputs(Project project, TaskInputs inputs, Object files) {
     if (compareGradleVersion(project, "3.0") >= 0) {
-      inputs.file(files).skipWhenEmpty()
+      inputs.files(files).skipWhenEmpty()
     } else {
       // source() is deprecated since Gradle 3.0
       inputs.source(files)

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -54,7 +54,7 @@ buildscript {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ["2.2.0", "2.2.0", "3.0.0-alpha7"]
-    gradleVersion << ["2.14.1", "3.0", "4.1-milestone-1", "4.3-rc-2"]
+    androidPluginVersion << ["2.2.0", "2.2.0", "3.0.0-beta7", "3.0.0-beta7"]
+    gradleVersion << ["2.14.1", "3.0", "4.1", "4.3-rc-2"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -55,6 +55,6 @@ buildscript {
 
     where:
     androidPluginVersion << ["2.2.0", "2.2.0", "3.0.0-alpha7"]
-    gradleVersion << ["2.14.1", "3.0", "4.1-milestone-1"]
+    gradleVersion << ["2.14.1", "3.0", "4.1-milestone-1", "4.3-rc-2"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -54,7 +54,13 @@ buildscript {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ["2.2.0", "2.2.0", "3.0.0-beta7", "3.0.0-beta7"]
-    gradleVersion << ["2.14.1", "3.0", "4.1", "4.3-rc-2"]
+    // Always make sure we have a pairing that includes the latest stable releases, and optionally
+    // the latest release candidates of each.
+    // Latest stable releases of android plugin:
+    //   https://developer.android.com/studio/releases/gradle-plugin.html
+    // Latest preview releases of android plugin:
+    //   https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html
+    androidPluginVersion << ["2.2.0", "2.2.0", "2.3.0", "3.0.0-beta7"]
+    gradleVersion << ["2.14.1", "3.0", "4.2", "4.3-rc-2"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -54,13 +54,7 @@ buildscript {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    // Always make sure we have a pairing that includes the latest stable releases, and optionally
-    // the latest release candidates of each.
-    // Latest stable releases of android plugin:
-    //   https://developer.android.com/studio/releases/gradle-plugin.html
-    // Latest preview releases of android plugin:
-    //   https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html
-    androidPluginVersion << ["2.2.0", "2.2.0", "2.3.0", "3.0.0-beta7"]
+    androidPluginVersion << ["2.2.0", "2.2.0", "2.3.0", "3.0.0-alpha7"]
     gradleVersion << ["2.14.1", "3.0", "4.2", "4.3-rc-2"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufAndroidPluginTest.groovy
@@ -54,7 +54,7 @@ buildscript {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ["2.2.0", "2.2.0", "2.3.0", "3.0.0-alpha7"]
+    androidPluginVersion << ["2.2.0", "2.2.0", "2.3.0", "2.3.0"]
     gradleVersion << ["2.14.1", "3.0", "4.2", "4.3-rc-2"]
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Specification
  * Unit tests for normal java functionality.
  */
 class ProtobufJavaPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSIONS = ["2.12", "3.0", "4.0"]
+  private static final List<String> GRADLE_VERSIONS = ["2.12", "3.0", "4.0", "4.3-rc-2"]
 
   private Project setupBasicProject() {
     Project project = ProjectBuilder.builder().build()


### PR DESCRIPTION
TaskInputs.file can only accept real files, not sourcesets:
https://discuss.gradle.org/t/gradle-4-3-rc1-is-available-for-testing/24415/16
