### PR TITLE
Proto generation spreading

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -462,7 +462,7 @@ public class GenerateProtoTask extends DefaultTask {
         if (idx > 0) {
           // If the major version is > 5, we are on Windows Vista or higher
           int majorVersion = Ints.tryParse(version[0..(idx - 1)]) ?: 0
-          if (majorVersion ?: 0 > 5) {
+          if (majorVersion > 5) {
             return VISTA_CMD_LENGTH_LIMIT
           }
         }

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -72,6 +72,14 @@ public class GenerateProtoTask extends DefaultTask {
   boolean generateDescriptorSet
 
   /**
+   * If true, protoc will be called once for each proto file instead of once with all files
+   * This allows the command line argument length limit can be avoided when many proto files are being generated
+   *
+   * Default: false
+   */
+  boolean spreadProtoGeneration
+
+  /**
    * Configuration object for descriptor generation details.
    */
   public class DescriptorSetOptions {
@@ -410,7 +418,20 @@ public class GenerateProtoTask extends DefaultTask {
       }
     }
 
+    if (spreadProtoGeneration) {
+      // If spreadProtoGeneration is enabled, call protoc once for each file
+      for (File proto : protoFiles) {
+        compileFiles(cmd, [ proto ])
+      }
+    } else {
+      compileFiles(cmd, protoFiles)
+    }
+  }
+
+  private void compileFiles(List<String> baseCmd, List<File> protoFiles) {
+    List<String> cmd = baseCmd.collect()
     cmd.addAll protoFiles
+
     logger.log(LogLevel.INFO, cmd.toString())
     StringBuffer stdout = new StringBuffer()
     StringBuffer stderr = new StringBuffer()

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -154,18 +154,90 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "test generateCmds should split commands appropriately"() {
+  void "test generateCmds should split commands when limit exceeded"() {
     given: "a cmd length limit and two proto files"
 
     String baseCmd = "protoc"
     List<File> protoFiles = [ new File("short.proto"), new File("long_proto_name.proto") ]
     int cmdLengthLimit = 32
 
-    when: "the commands are split"
+    when: "the commands are generated"
 
     List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
 
     then: "it splits appropriately"
     cmds.size() == 2
+  }
+
+  void "test generateCmds should not split commands when under limit"() {
+    given: "a cmd length limit and two proto files"
+
+    String baseCmd = "protoc"
+    List<File> protoFiles = [ new File("short.proto"), new File("long_proto_name.proto") ]
+    int cmdLengthLimit = 64
+
+    when: "the commands are generated"
+
+    List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
+
+    then: "it splits appropriately"
+    cmds.size() == 1
+  }
+
+  void "test generateCmds should not return commands when no protos are given"() {
+    given: "a cmd length limit and no proto files"
+
+    String baseCmd = "protoc"
+    List<File> protoFiles = []
+    int cmdLengthLimit = 32
+
+    when: "the commands are generated"
+
+    List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
+
+    then: "it returns no commands"
+    cmds.size() == 0
+  }
+
+  void "test getCmdLengthLimit returns correct limit for Windows XP"() {
+    given: "Windows OS at major version 5"
+
+    String os = "windows"
+    String version = "5.0.0"
+
+    when: "the command length limit is queried"
+
+    int limit = GenerateProtoTask.getCmdLengthLimit(os, version)
+
+    then: "it returns the XP limit"
+    limit == GenerateProtoTask.XP_CMD_LENGTH_LIMIT
+  }
+
+  void "test getCmdLengthLimit returns correct limit for Windows Vista"() {
+    given: "Windows OS at major version 6"
+
+    String os = "Windows"
+    String version = "6.0.0"
+
+    when: "the command length limit is queried"
+
+    int limit = GenerateProtoTask.getCmdLengthLimit(os, version)
+
+    then: "it returns the Vista limit"
+    limit == GenerateProtoTask.VISTA_CMD_LENGTH_LIMIT
+  }
+
+  void "test getCmdLengthLimit returns correct limit for non-Windows OS"() {
+    given: "MacOS X at major version 10"
+
+    String os = "Mac OS X"
+    String version = "10.0.0"
+
+    when: "the command length limit is queried"
+
+    int limit = GenerateProtoTask.getCmdLengthLimit(os, version)
+
+    then: "it returns maximum integer value"
+    limit == Integer.MAX_VALUE
   }
 }

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -166,7 +166,7 @@ class ProtobufJavaPluginTest extends Specification {
     List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
 
     then: "it splits appropriately"
-    cmds.size() == 2
+    cmds.size() == 2 && cmds[0] == "protoc short.proto" && cmds[1] == "protoc long_proto_name.proto"
   }
 
   void "test generateCmds should not split commands when under limit"() {
@@ -181,7 +181,7 @@ class ProtobufJavaPluginTest extends Specification {
     List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
 
     then: "it splits appropriately"
-    cmds.size() == 1
+    cmds.size() == 1 && cmds[0] == "protoc short.proto long_proto_name.proto"
   }
 
   void "test generateCmds should not return commands when no protos are given"() {
@@ -196,7 +196,7 @@ class ProtobufJavaPluginTest extends Specification {
     List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
 
     then: "it returns no commands"
-    cmds.size() == 0
+    cmds.isEmpty()
   }
 
   void "test getCmdLengthLimit returns correct limit for Windows XP"() {

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -153,4 +153,19 @@ class ProtobufJavaPluginTest extends Specification {
     where:
     gradleVersion << GRADLE_VERSIONS
   }
+
+  void "test generateCmds should split commands appropriately"() {
+    given: "a cmd length limit and two proto files"
+
+    String baseCmd = "protoc"
+    List<File> protoFiles = [ new File("short.proto"), new File("long_proto_name.proto") ]
+    int cmdLengthLimit = 32
+
+    when: "the commands are split"
+
+    List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
+
+    then: "it splits appropriately"
+    cmds.size() == 2
+  }
 }


### PR DESCRIPTION
This PR spreads proto generation over multiple `protoc` calls when on Windows. Once the command length exceeds the OS limit, it calls with the current arguments and resets the builder. 

This is related to #167, allowing this issue to be avoided when many proto files are present, until https://github.com/google/protobuf/issues/274 is completed.