### PR TITLE
Remove the example that uses the snapshot repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,30 +33,17 @@ buildscript {
 }
 ```
 
-Latest changes are included in the SNAPSHOT artifact:
-```gradle
-buildscript {
-  repositories {
-    maven {
-       url 'https://oss.sonatype.org/content/repositories/snapshots/'
-    }
-  }
-  dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3-SNAPSHOT'
-  }
-}
-```
+To try out the head version, you can download the source and build it
+with ``./gradlew install -x test`` (we skip tests here because they
+require Android SDK), then:
 
-However, the availability and freshness of the SNAPSHOT artifact are not
-guaranteed. You can instead download the source and build it with ``./gradlew
-install``, then:
 ```gradle
 buildscript {
   repositories {
     mavenLocal()
   }
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3-SNAPSHOT'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.4-SNAPSHOT'
   }
 }
 ```


### PR DESCRIPTION
We rarely push the snapshots.  On the other hand, building the
snapshot locally is pretty straightforward.

Resolves #179