### PR TITLE
Make intellij plugin aware of java generated source dirs

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -197,10 +197,11 @@ public class GenerateProtoTask extends DefaultTask {
   void doneConfig() {
     Preconditions.checkState(state == State.CONFIG, "Invalid state: ${state}")
     state = State.FINALIZED
+    String sourceSetOrVariantName = Utils.isAndroidProject(project) ? variant.name : sourceSet.name
     // builtins and plugins can be repeatedly modified until doneConfig() is called.
     // Now that they are finalized, register the directories with intellij.
     [builtins, plugins]*.each {
-      Utils.addToIdeSources(project, sourceSet.name, new File(getOutputDir(it)))
+      Utils.addToIdeSources(project, sourceSetOrVariantName, new File(getOutputDir(it)))
     }
   }
 

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -197,6 +197,11 @@ public class GenerateProtoTask extends DefaultTask {
   void doneConfig() {
     Preconditions.checkState(state == State.CONFIG, "Invalid state: ${state}")
     state = State.FINALIZED
+    // builtins and plugins can be repeatedly modified until doneConfig() is called.
+    // Now that they are finalized, register the directories with intellij.
+    [builtins, plugins]*.each {
+      Utils.addToIdeSources(project, sourceSet.name, new File(getOutputDir(it)))
+    }
   }
 
   String getDescriptorPath() {
@@ -218,7 +223,7 @@ public class GenerateProtoTask extends DefaultTask {
   //===========================================================================
 
   /**
-   * Configures the protoc builtins in a closure, which will be maniuplating a
+   * Configures the protoc builtins in a closure, which will be manipulating a
    * NamedDomainObjectContainer<PluginOptions>.
    */
   public void builtins(Closure configureClosure) {

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -109,6 +109,8 @@ class Utils {
   static void addToIdeSources(Project project, String sourceSetName, File f) {
     IdeaModel model = project.getExtensions().findByType(IdeaModel)
     if (model != null) {
+      // TODO(zpencer): switch to model.module.generatedSourceDirs when that API becomes stable
+      // For now, just hint to the IDE that it's a source dir or a test source dir.
       if (isTest(sourceSetName)) {
         model.module.testSourceDirs += f
       } else {

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -187,21 +187,25 @@ class ProtobufJavaPluginTest extends Specification {
     assert Objects.equals(
             sourceDir,
             ImmutableSet.builder()
-                    .add('file://$MODULE_DIR$/src/main/java')
-                    .add('file://$MODULE_DIR$/src/grpc/proto')
-                    .add('file://$MODULE_DIR$/src/main/proto')
-                    .add('file://$MODULE_DIR$/build/extracted-include-protos/grpc')
-                    .add('file://$MODULE_DIR$/build/extracted-protos/main')
-                    .add('file://$MODULE_DIR$/build/extracted-include-protos/main')
-                    .add('file://$MODULE_DIR$/build/extracted-protos/grpc')
-                    .build())
+                .add('file://$MODULE_DIR$/src/main/java')
+                .add('file://$MODULE_DIR$/src/grpc/proto')
+                .add('file://$MODULE_DIR$/src/main/proto')
+                .add('file://$MODULE_DIR$/build/extracted-include-protos/grpc')
+                .add('file://$MODULE_DIR$/build/extracted-protos/main')
+                .add('file://$MODULE_DIR$/build/extracted-include-protos/main')
+                .add('file://$MODULE_DIR$/build/extracted-protos/grpc')
+                .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/java')
+                .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/grpc_output')
+                .add('file://$MODULE_DIR$/build/generated/source/proto/main/java')
+                .build())
     assert Objects.equals(
             testSourceDir,
             ImmutableSet.builder()
-                    .add('file://$MODULE_DIR$/src/test/java')
-                    .add('file://$MODULE_DIR$/src/test/proto')
-                    .add('file://$MODULE_DIR$/build/extracted-protos/test')
-                    .add('file://$MODULE_DIR$/build/extracted-include-protos/test')
+                .add('file://$MODULE_DIR$/src/test/java')
+                .add('file://$MODULE_DIR$/src/test/proto')
+                .add('file://$MODULE_DIR$/build/extracted-protos/test')
+                .add('file://$MODULE_DIR$/build/extracted-include-protos/test')
+                .add('file://$MODULE_DIR$/build/generated/source/proto/test/java')
             .build())
 
     where:


### PR DESCRIPTION
This is just a hint to the IDE so it side steps the issues outlined
here:
https://github.com/google/protobuf-gradle-plugin/pull/68