### PR TITLE
Clean up proto and gen java idea integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,9 +466,9 @@ Settings -> Build, Execution, Deployment
   -> Delegate IDE build/run actions to gradle.
 ```
 
-If IntelliJ complains that the generated classes are not found, you
-can include the following block in you `build.gradle` to ask IntelliJ
-to include the generated Java directories as source folders using the IDEA plugin.
+This plugin integrates with the ``idea`` plugin and automatically
+registers the proto files and generated Java code as sources.
+
 
 ```gradle
 apply plugin: 'idea'
@@ -484,9 +484,10 @@ clean {
 
 idea {
     module {
-        sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/java");
-        // If you have additional sourceSets and/or codegen plugins, add all of them
-        sourceDirs += file("${protobuf.generatedFilesBaseDir}/main/grpc");
+        // proto files and generated Java files are automatically added as
+        // source dirs.
+        // If you have additional sources, add them here:
+        sourceDirs += file("/path/to/other/sources");
     }
 }
 ```

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -197,12 +197,6 @@ public class GenerateProtoTask extends DefaultTask {
   void doneConfig() {
     Preconditions.checkState(state == State.CONFIG, "Invalid state: ${state}")
     state = State.FINALIZED
-    String sourceSetOrVariantName = Utils.isAndroidProject(project) ? variant.name : sourceSet.name
-    // builtins and plugins can be repeatedly modified until doneConfig() is called.
-    // Now that they are finalized, register the directories with intellij.
-    [builtins, plugins]*.each {
-      Utils.addToIdeSources(project, sourceSetOrVariantName, new File(getOutputDir(it)))
-    }
   }
 
   String getDescriptorPath() {
@@ -273,6 +267,17 @@ public class GenerateProtoTask extends DefaultTask {
       includeDirs.add(dir)
     } else {
       includeDirs.add(project.file(dir))
+    }
+  }
+
+  /**
+   * Returns true if the Java source set or Android variant is test related.
+   */
+  public boolean getIsTest() {
+    if (Utils.isAndroidProject(project)) {
+      return isTestVariant
+    } else {
+      return Utils.isTest(sourceSet.name)
     }
   }
 

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -42,11 +42,21 @@ class ProtobufExtract extends DefaultTask {
    * The directory for the extracted files.
    */
   private File destDir
+  private Boolean isTest = null
 
   protected void setDestDir(File destDir) {
     Preconditions.checkState(this.destDir == null, 'destDir already set')
     this.destDir = destDir
     outputs.dir destDir
+  }
+
+  public void setIsTest(boolean isTest) {
+    this.isTest = isTest
+  }
+
+  public boolean getIsTest() {
+    Preconditions.checkNotNull(isTest)
+    return isTest
   }
 
   protected File getDestDir() {

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -106,12 +106,12 @@ class Utils {
    * Adds the file to the IDE plugin's set of sources / resources. If the directory does
    * not exist, it will be created before the IDE task is run.
    */
-  static void addToIdeSources(Project project, String sourceSetName, File f) {
+  static void addToIdeSources(Project project, boolean isTest, File f) {
     IdeaModel model = project.getExtensions().findByType(IdeaModel)
     if (model != null) {
       // TODO(zpencer): switch to model.module.generatedSourceDirs when that API becomes stable
       // For now, just hint to the IDE that it's a source dir or a test source dir.
-      if (isTest(sourceSetName)) {
+      if (isTest) {
         model.module.testSourceDirs += f
       } else {
         model.module.sourceDirs += f
@@ -119,8 +119,8 @@ class Utils {
       project.tasks.withType(GenerateIdeaModule).each {
         it.doFirst {
           // This is required because the intellij plugin does not allow adding source directories
-          // that do not exist. The intellij config files to be valid from the start even if a user
-          // runs './gradlew idea' before running './gradlew generateProto'.
+          // that do not exist. The intellij config files should be valid from the start even if a
+          // user runs './gradlew idea' before running './gradlew generateProto'.
           f.mkdirs()
         }
       }

--- a/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/plugins/ProtobufJavaPluginTest.groovy
@@ -155,7 +155,7 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProject proto directories should be successfully added to intellij"() {
+  void "testProject proto and generated output directories should be added to intellij"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.prepareTestTempDir('testProject')
     ProtobufPluginTestHelper.copyTestProject(projectDir, 'testProject', )
@@ -184,29 +184,27 @@ class ProtobufJavaPluginTest extends Specification {
       }
     }
 
-    assert Objects.equals(
-            sourceDir,
-            ImmutableSet.builder()
-                .add('file://$MODULE_DIR$/src/main/java')
-                .add('file://$MODULE_DIR$/src/grpc/proto')
-                .add('file://$MODULE_DIR$/src/main/proto')
-                .add('file://$MODULE_DIR$/build/extracted-include-protos/grpc')
-                .add('file://$MODULE_DIR$/build/extracted-protos/main')
-                .add('file://$MODULE_DIR$/build/extracted-include-protos/main')
-                .add('file://$MODULE_DIR$/build/extracted-protos/grpc')
-                .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/java')
-                .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/grpc_output')
-                .add('file://$MODULE_DIR$/build/generated/source/proto/main/java')
-                .build())
-    assert Objects.equals(
-            testSourceDir,
-            ImmutableSet.builder()
-                .add('file://$MODULE_DIR$/src/test/java')
-                .add('file://$MODULE_DIR$/src/test/proto')
-                .add('file://$MODULE_DIR$/build/extracted-protos/test')
-                .add('file://$MODULE_DIR$/build/extracted-include-protos/test')
-                .add('file://$MODULE_DIR$/build/generated/source/proto/test/java')
-            .build())
+    Set<String> expectedSourceDir = ImmutableSet.builder()
+        .add('file://$MODULE_DIR$/src/main/java')
+        .add('file://$MODULE_DIR$/src/grpc/proto')
+        .add('file://$MODULE_DIR$/src/main/proto')
+        .add('file://$MODULE_DIR$/build/extracted-include-protos/grpc')
+        .add('file://$MODULE_DIR$/build/extracted-protos/main')
+        .add('file://$MODULE_DIR$/build/extracted-include-protos/main')
+        .add('file://$MODULE_DIR$/build/extracted-protos/grpc')
+        .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/java')
+        .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/grpc_output')
+        .add('file://$MODULE_DIR$/build/generated/source/proto/main/java')
+        .build()
+    Set<String> expectedTestSourceDir = ImmutableSet.builder()
+        .add('file://$MODULE_DIR$/src/test/java')
+        .add('file://$MODULE_DIR$/src/test/proto')
+        .add('file://$MODULE_DIR$/build/extracted-protos/test')
+        .add('file://$MODULE_DIR$/build/extracted-include-protos/test')
+        .add('file://$MODULE_DIR$/build/generated/source/proto/test/java')
+        .build()
+    assert Objects.equals(expectedSourceDir, sourceDir)
+    assert Objects.equals(expectedTestSourceDir, testSourceDir)
 
     where:
     gradleVersion << GRADLE_VERSIONS


### PR DESCRIPTION
Make all the calls to addToIdeSources happen in the same place.

Amend readme, comments, and tests.