### PR TITLE
fix gotcha that requires kotlin plugin be applied before protobuf

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -32,7 +32,6 @@ import com.google.common.base.Preconditions
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskInputs
 import org.gradle.plugins.ide.idea.GenerateIdeaModule
@@ -67,14 +66,14 @@ class Utils {
   }
 
   /**
-   * Returns the compile task for Kotlin.
+   * Returns the compile task name for Kotlin.
    */
-  static Task getKotlinAndroidCompileTask(Project project, String variantName) {
+  static String getKotlinAndroidCompileTaskName(Project project, String variantName) {
     // The kotlin plugin does not provide a utility for this.
     // Fortunately, the naming scheme is well defined:
     // https://kotlinlang.org/docs/reference/using-gradle.html#compiler-options
     Preconditions.checkState(isAndroidProject(project))
-    return project.tasks.findByName("compile" + GUtil.toCamelCase(variantName) + "Kotlin")
+    return "compile" + GUtil.toCamelCase(variantName) + "Kotlin"
   }
 
   static void addFilesToTaskInputs(Project project, TaskInputs inputs, Object files) {

--- a/testProjectAndroidKotlin/build.gradle
+++ b/testProjectAndroidKotlin/build.gradle
@@ -1,8 +1,9 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
 
-apply plugin: 'com.android.application'
+// it is not necessary for protobuf to be applied last
 apply plugin: 'com.google.protobuf'
+apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 apply from: 'build_base.gradle'


### PR DESCRIPTION
I mentioned I noticed some weirdness while working on the plugin
for android. It was caused by the unit test project applying
protobuf before kotlin-android. The result is that when the
proto plugin is configured, the kotlin tasks will not be created
yet.

This PR fixes the issue and allows applying plugins in any order.