### PR TITLE
Stop flattening protoc command line.

### DIFF
--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -256,43 +256,43 @@ class ProtobufJavaPluginTest extends Specification {
   void "test generateCmds should split commands when limit exceeded"() {
     given: "a cmd length limit and two proto files"
 
-    String baseCmd = "protoc"
+    List<String> baseCmd = ["protoc"]
     List<File> protoFiles = [ new File("short.proto"), new File("long_proto_name.proto") ]
     int cmdLengthLimit = 32
 
     when: "the commands are generated"
 
-    List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
+    List<List<String>> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
 
     then: "it splits appropriately"
-    cmds.size() == 2 && cmds[0] == "protoc short.proto" && cmds[1] == "protoc long_proto_name.proto"
+    cmds.size() == 2 && cmds[0] == ["protoc", "short.proto"] && cmds[1] == ["protoc", "long_proto_name.proto"]
   }
 
   void "test generateCmds should not split commands when under limit"() {
     given: "a cmd length limit and two proto files"
 
-    String baseCmd = "protoc"
+    List<String> baseCmd = ["protoc"]
     List<File> protoFiles = [ new File("short.proto"), new File("long_proto_name.proto") ]
     int cmdLengthLimit = 64
 
     when: "the commands are generated"
 
-    List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
+    List<List<String>> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
 
     then: "it splits appropriately"
-    cmds.size() == 1 && cmds[0] == "protoc short.proto long_proto_name.proto"
+    cmds.size() == 1 && cmds[0] == ["protoc", "short.proto", "long_proto_name.proto"]
   }
 
   void "test generateCmds should not return commands when no protos are given"() {
     given: "a cmd length limit and no proto files"
 
-    String baseCmd = "protoc"
+    List<String> baseCmd = ["protoc"]
     List<File> protoFiles = []
     int cmdLengthLimit = 32
 
     when: "the commands are generated"
 
-    List<String> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
+    List<List<String>> cmds = GenerateProtoTask.generateCmds(baseCmd, protoFiles, cmdLengthLimit)
 
     then: "it returns no commands"
     cmds.isEmpty()

--- a/testProjectCustomProtoDir/build.gradle
+++ b/testProjectCustomProtoDir/build.gradle
@@ -14,6 +14,7 @@ sourceSets {
       // In addition to the default 'src/main/proto'
       srcDir 'src/main/protobuf'
       srcDir 'src/main/protocolbuffers'
+      srcDir 'src/main/protocol buffers'
       // In addition to '**/*.proto' (use with caution).
       // Using an extension other than 'proto' is NOT recommended, because when
       // proto files are published along with class files, we can only tell the

--- a/testProjectCustomProtoDir/src/main/java/Foo.java
+++ b/testProjectCustomProtoDir/src/main/java/Foo.java
@@ -17,9 +17,8 @@ public class Foo {
     // from src/main/protocolbuffers/more.proto
     list.add(More.MoreMsg.getDefaultInstance());
     list.add(More.Foo.getDefaultInstance());
-    // from "src/main/protocol buffers/more2.proto"
-    list.add(More2.MoreMsg2.getDefaultInstance());
-    list.add(More2.Foo2.getDefaultInstance());
+    // from "src/main/protocol buffers/spaceinpath.proto"
+    list.add(Spaceinpath.SpaceInPath.getDefaultInstance());
     return list;
   }
 }

--- a/testProjectCustomProtoDir/src/main/java/Foo.java
+++ b/testProjectCustomProtoDir/src/main/java/Foo.java
@@ -17,6 +17,9 @@ public class Foo {
     // from src/main/protocolbuffers/more.proto
     list.add(More.MoreMsg.getDefaultInstance());
     list.add(More.Foo.getDefaultInstance());
+    // from "src/main/protocol buffers/more2.proto"
+    list.add(More2.MoreMsg2.getDefaultInstance());
+    list.add(More2.Foo2.getDefaultInstance());
     return list;
   }
 }

--- a/testProjectCustomProtoDir/src/main/protocol buffers/more2.proto
+++ b/testProjectCustomProtoDir/src/main/protocol buffers/more2.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message MoreMsg2 {
+    string bar = 1;
+}
+
+message Foo2 {
+    string stuff = 1;
+}

--- a/testProjectCustomProtoDir/src/main/protocol buffers/more2.proto
+++ b/testProjectCustomProtoDir/src/main/protocol buffers/more2.proto
@@ -1,9 +1,0 @@
-syntax = "proto3";
-
-message MoreMsg2 {
-    string bar = 1;
-}
-
-message Foo2 {
-    string stuff = 1;
-}

--- a/testProjectCustomProtoDir/src/main/protocol buffers/spaceinpath.proto
+++ b/testProjectCustomProtoDir/src/main/protocol buffers/spaceinpath.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message SpaceInPath {
+    string bar = 1;
+}

--- a/testProjectCustomProtoDir/src/test/java/FooTest.java
+++ b/testProjectCustomProtoDir/src/test/java/FooTest.java
@@ -2,7 +2,7 @@
 public class FooTest {
   @org.junit.Test
   public void testMainProtos() {
-    org.junit.Assert.assertEquals(8, Foo.getDefaultInstances().size());
+    org.junit.Assert.assertEquals(10, Foo.getDefaultInstances().size());
   }
 
   @org.junit.Test

--- a/testProjectCustomProtoDir/src/test/java/FooTest.java
+++ b/testProjectCustomProtoDir/src/test/java/FooTest.java
@@ -2,7 +2,7 @@
 public class FooTest {
   @org.junit.Test
   public void testMainProtos() {
-    org.junit.Assert.assertEquals(10, Foo.getDefaultInstances().size());
+    org.junit.Assert.assertEquals(9, Foo.getDefaultInstances().size());
   }
 
   @org.junit.Test


### PR DESCRIPTION
Keep the command line as a list of arguments so that spaces in
arguments will not be mistaken as argument delimiters.

Resolves #212