### PR TITLE
Make it easier to debug android build issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ dependencies {
 
     testProjectRuntime "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.0"
 
+    // Add android plugin to the test classpath, so that we can jump into class definitions,
+    // read their sources, set break points, etc while debugging android unit tests.
+    // Change the version if necessary to match the specific unit test.
+    testRuntime 'com.android.tools.build:gradle:2.3.0'
     // Add the classpath file to the test runtime classpath
     testRuntime files(createClasspathManifest)
 }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -68,7 +68,7 @@ class ProtobufAndroidPluginTest extends Specification {
     // classpath correctly.
     new File(mainProjectDir, "build.gradle") << """
 buildscript {
-    String androidPluginVersion = System.properties.get("ANDROID_PLUGIN_VERSION") ?: "2.2.0"
+    String androidPluginVersion = "${androidPluginVersion}"
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
         if (androidPluginVersion.startsWith("3.")) {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -88,7 +88,6 @@ buildscript {
     return GradleRunner.create()
         .withProjectDir(mainProjectDir)
         .withArguments(
-        "-DANDROID_PLUGIN_VERSION=${androidPluginVersion}",
         // set android build cache to avoid using home directory on travis CI.
         "-Pandroid.buildCacheDir=" + localBuildCache,
         "testProjectAndroid:build",


### PR DESCRIPTION
- add testRuntime dep on android plugin, so that if we step through
  the android tests with a debugger, the class definitions are
  available.
- hard code the correct android version in the generated test project,
  so that it can be loaded without modifications to android studio