### PR TITLE
Register unitTest generated sources with android studio

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -508,8 +508,10 @@ class ProtobufPlugin implements Plugin<Project> {
         // We must avoid using private android APIs to find subprojects that the variant depends
         // on, such as by walking through
         //   variant.variantData.variantDependency.compileConfiguration.allDependencies
-        // In theory, we should be able to take an arbitrary task and walk its dependency
-        // graph using only vanilla Gradle APIs to identify all parent GenerateProtoTasks.
+        // Gradle.getTaskGraph().getDependencies() should allow us to walk the task graph,
+        // but unfortunately that API is @Incubating. We can revisit it when it becomes stable.
+        // https://docs.gradle.org/4.8/javadoc/org/gradle/api/execution/
+        // TaskExecutionGraph.html#getDependencies-org.gradle.api.Task-
 
         // TODO(zpencer): find a way to make android studio aware of the .proto files
         // Simply adding the .proto dirs via addJavaSourceFoldersToModel does not seem to work.

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -490,14 +490,10 @@ class ProtobufPlugin implements Plugin<Project> {
      * Adds proto sources and generated sources to supported IDE plugins.
      */
     private void addSourcesToIde() {
-      // The generated javalite sources have lint issues:
-      //   https://github.com/google/protobuf/pull/2823.
-      // Strangely, this does not cause Android Studio warnings for sources registered via
-      // registerJavaGeneratingTask. Only these extra sources cause problems.
-      // If users would rather have a clean Android Studio project refresh than registered
-      // sources, they can use the flag to disable this section.
-      if (Utils.isAndroidProject(project)
-          && project.getProperties().get('protobuf.androidstudio.extrasrcs.experimental', true)) {
+      // The generated javalite sources have lint issues. This is fixed upstream but
+      // there is still no release with the fix yet.
+      //   https://github.com/google/protobuf/pull/2823
+      if (Utils.isAndroidProject(project)) {
         // variant.registerJavaGeneratingTask called earlier already registers the generated
         // sources for normal variants, but unit test variants work differently and do not
         // use registerJavaGeneratingTask. Let's call addJavaSourceFoldersToModel for all tasks

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -36,7 +36,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection


### PR DESCRIPTION
It turns out, android studio does not use the `idea` plugin and
instead does its own thing.

The android project's non local unit test protos are automatically
registered when we call `registerJavaGeneratingTask`. But local unit
tests run without the android SDK, and `registerJavaGeneratingTask` is
not implemented. They must be registered explicitly.

Also, an Android sub project can depend on another subproject that has
GenerateProtoTasks. We must scan through each variant and find such
subproject dependencies, and register their gen outputs.

Android Studio automatically ignores linter warnings for
`registerJavaGeneratingTask` sources, but for these sources it will
warn. Unfortunately the current version of proto lite generates code
that fails lint, and this causes warnings. But I think the typical
user would rather see warnings than have sources not be registered at
all, so turning this on by default makes sense.

To disable this behavior, set the project property:
protobuf.androidstudio.extrasrcs.experimental=false

fixes https://github.com/google/protobuf-gradle-plugin/issues/229