### PR TITLE
Avoid android private API: variant.variantData

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -238,7 +238,7 @@ class ProtobufPlugin implements Plugin<Project> {
     private addTasksForVariant(final Object variant, boolean isTestVariant) {
       Task generateProtoTask = addGenerateProtoTask(variant.name, variant.sourceSets)
       generateProtoTask.setVariant(variant, isTestVariant)
-      generateProtoTask.flavors = ImmutableList.copyOf(variant.productFlavors.collect {it.name})
+      generateProtoTask.flavors = ImmutableList.copyOf(variant.productFlavors.collect { it.name })
       if (variant.hasProperty('buildType')) {
         generateProtoTask.buildType = variant.buildType.name
       }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -193,7 +193,7 @@ class ProtobufPlugin implements Plugin<Project> {
      */
     private addProtoTasks() {
       if (Utils.isAndroidProject(project)) {
-        (getNonTestVariants()).each { variant ->
+        getNonTestVariants().each { variant ->
           addTasksForVariant(variant, false)
         }
         (project.android.unitTestVariants + project.android.testVariants).each { variant ->

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -238,7 +238,7 @@ class ProtobufPlugin implements Plugin<Project> {
     private addTasksForVariant(final Object variant, boolean isTestVariant) {
       Task generateProtoTask = addGenerateProtoTask(variant.name, variant.sourceSets)
       generateProtoTask.setVariant(variant, isTestVariant)
-      generateProtoTask.flavors = ImmutableList.copyOf(variant.productFlavors.collect { it.name })
+      generateProtoTask.flavors = ImmutableList.copyOf(variant.productFlavors.collect { it.name } )
       if (variant.hasProperty('buildType')) {
         generateProtoTask.buildType = variant.buildType.name
       }


### PR DESCRIPTION
This returns an internal class and we should avoid this call.

It makes sense just to query for `variant.sourceSets`
or `variant.productFlavors` rather than building up the source sets
ourselves. 

It actually looks like the list that we create ourselves is missing a source
set during testing:
Example 1
```
variant.sourceSets
0 = "main"
1 = "freeapp"
2 = "x86"
3 = "x86Freeapp"
4 = "debug"
5 = "x86FreeappDebug"

sourceSetNames
 0 = "main"
 1 = "main"
 2 = "x86FreeappDebug"
 3 = "debug"
 4 = "x86"
 5 = "freeapp"
 ```
Example 2
```
variant.sourceSets
 0 = "main"
 1 = "retailapp"
 2 = "x86"
 3 = "x86Retailapp"
 4 = "release"
 5 = "x86RetailappRelease"

sourceSetNames
 0 = "main"
 1 = "main"
 2 = "x86RetailappRelease"
 3 = "release"
 4 = "x86"
 5 = "retailapp"
```