### PR TITLE
Switch configurator to return `TaskCollection` instead of normal `Col…

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
@@ -30,6 +30,7 @@ package com.google.protobuf.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.tasks.TaskCollection
 import org.gradle.util.ConfigureUtil
 
 /**
@@ -113,44 +114,48 @@ public class ProtobufConfigurator {
   }
 
   public class GenerateProtoTaskCollection {
-    public Collection<GenerateProtoTask> all() {
-      return project.tasks.findAll { task ->
-        task instanceof GenerateProtoTask
-      }
+    public TaskCollection<GenerateProtoTask> all() {
+      return project.tasks.withType(GenerateProtoTask)
     }
   }
 
   public class AndroidGenerateProtoTaskCollection
       extends GenerateProtoTaskCollection {
-    public Collection<GenerateProtoTask> ofFlavor(String flavor) {
-      return all().findAll { task ->
+    public TaskCollection<GenerateProtoTask> ofFlavor(String flavor) {
+      return all().matching { GenerateProtoTask task ->
         task.flavors.contains(flavor)
       }
     }
 
-    public Collection<GenerateProtoTask> ofBuildType(String buildType) {
-      return all().findAll { task ->
+    public TaskCollection<GenerateProtoTask> ofBuildType(String buildType) {
+      return all().matching { GenerateProtoTask task ->
         task.buildType == buildType
       }
     }
 
-    public Collection<GenerateProtoTask> ofVariant(String variant) {
-      return all().findAll { task ->
+    public TaskCollection<GenerateProtoTask> ofVariant(String variant) {
+      return all().matching { GenerateProtoTask task ->
         task.variant.name == variant
       }
     }
-    public Collection<GenerateProtoTask> ofNonTest() {
-      return all().findAll { task -> !task.isTestVariant }
+
+    public TaskCollection<GenerateProtoTask> ofNonTest() {
+      return all().matching { GenerateProtoTask task ->
+        !task.isTestVariant
+      }
     }
-    public Collection<GenerateProtoTask> ofTest() {
-      return all().findAll { task -> task.isTestVariant }
+
+    public TaskCollection<GenerateProtoTask> ofTest() {
+      return all().matching { GenerateProtoTask task ->
+        task.isTestVariant
+      }
     }
   }
 
   public class JavaGenerateProtoTaskCollection
       extends GenerateProtoTaskCollection {
-    public Collection<GenerateProtoTask> ofSourceSet(String sourceSet) {
-      return all().findAll { task ->
+    public TaskCollection<GenerateProtoTask> ofSourceSet(String sourceSet) {
+      return all().matching { GenerateProtoTask task ->
         task.sourceSet.name == sourceSet
       }
     }


### PR DESCRIPTION
…lection`

The `TaskCollection` is a better Gradle type to be used for lazy configuration and configuration avoidance.

see https://github.com/gradle/gradle/issues/5664#issuecomment-409797173