### PR TITLE
Remove Guava and commons-lang dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     testCompile gradleApi()
     testCompile localGroovy()
     testCompile 'junit:junit:4.12'
-    testCompile ('org.spockframework:spock-core:1.0-groovy-2.4') {
+    testCompile ('org.spockframework:spock-core:1.1-groovy-2.4') {
       exclude module : 'groovy-all'
     }
     testCompile 'commons-io:commons-io:2.5'

--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,7 @@ task createClasspathManifest {
 dependencies {
     compileOnly gradleApi()
     compileOnly localGroovy()
-    compile 'com.google.guava:guava:18.0'
     compile 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
-    compile 'commons-lang:commons-lang:2.6'
 
     testCompile gradleTestKit()
     testCompile gradleApi()

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     testCompile ('org.spockframework:spock-core:1.1-groovy-2.4') {
       exclude module : 'groovy-all'
     }
-    testCompile 'commons-io:commons-io:2.5'
+    testCompile 'commons-io:commons-io:2.6'
 
     testProjectRuntime "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.12.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.20.0"
     }
 }
 

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -29,7 +29,6 @@
 package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
-import org.apache.commons.lang.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet
@@ -49,7 +48,7 @@ class Utils {
    */
   static String getConfigName(String sourceSetName, String type) {
     return sourceSetName == SourceSet.MAIN_SOURCE_SET_NAME ?
-        type : (sourceSetName + StringUtils.capitalize(type))
+        type : (sourceSetName + type.capitalize())
   }
 
   /**
@@ -58,7 +57,7 @@ class Utils {
    */
   static String getSourceSetSubstringForTaskNames(String sourceSetName) {
     return sourceSetName == SourceSet.MAIN_SOURCE_SET_NAME ?
-        '' : StringUtils.capitalize(sourceSetName)
+        '' : sourceSetName.capitalize()
   }
 
   private static final String ANDROID_BASE_PLUGIN_ID = "com.android.base"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -131,8 +131,8 @@ buildscript {
 
     File build() {
       File projectDir = new File(System.getProperty('user.dir'), 'build/tests/' + testProjectName)
-      FileUtils.deleteDirectory(projectDir)
-      FileUtils.forceMkdir(projectDir)
+      projectDir.deleteDir()
+      projectDir.mkdirs()
       sourceDirs.each {
         FileUtils.copyDirectory(new File(System.getProperty("user.dir"), it), projectDir)
       }


### PR DESCRIPTION
They were barely used (and Guava not at all) and this reduces the chance of conflicting with other plugins that do use those dependencies.