### PR TITLE
Allow referencing "undefined" plugins.

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -423,12 +423,13 @@ public class GenerateProtoTask extends DefaultTask {
     plugins.each { plugin ->
       String name = plugin.name
       ExecutableLocator locator = tools.plugins.findByName(name)
-      if (locator == null) {
-        throw new GradleException("Codegen plugin ${name} not defined")
+      if (locator != null) {
+        baseCmd += "--plugin=protoc-gen-${name}=${locator.path}"
+      } else {
+        logger.warn "protoc plugin '${name}' not defined. Trying to use 'protoc-gen-${name}' from system path"
       }
       String pluginOutPrefix = makeOptionsPrefix(plugin.options)
       baseCmd += "--${name}_out=${pluginOutPrefix}${getOutputDir(plugin)}"
-      baseCmd += "--plugin=protoc-gen-${name}=${locator.path}"
     }
 
     if (generateDescriptorSet) {


### PR DESCRIPTION
protoc will by default look for protoc-gen-${name} from system search
path.  In cases plugins need to be installed locally, this would allow
projects to be able to use the locally installed plugins without
having to check in their absolute paths.

Resolves #263