### PR TITLE
Raise minimum JDK version to 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information about the Protobuf Compiler, please refer to
 [Google Developers Site](https://developers.google.com/protocol-buffers/docs/reference/java-generated?csw=1).
 
 ## Latest Version
-The latest version is ``0.8.6``. It requires at least __Gradle 2.12__ and __Java 7__.
+The latest version is ``0.8.6``. It requires at least __Gradle 2.12__ and __Java 8__.
 It is available on Maven Central. To add dependency to it:
 ```gradle
 buildscript {


### PR DESCRIPTION
The latest Kotlin compiler requires JDK 8 (source:
https://blog.jetbrains.com/kotlin/2017/04/kotlin-1-1-2-is-out/).  The
Android plugin has been requiring JDK 8 too, although previous
release was able to build with Java 7 skipping the Android tests.

As the Kotlin changes has merged, the head currently cannot build with Java 7 any more.