### PR TITLE
Only consider relative paths when adding files to task inputs.

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -304,7 +304,7 @@ class ProtobufPlugin implements Plugin<Project> {
         it.fileResolver = this.fileResolver
         sourceSets.each { sourceSet ->
           // Include sources
-          Utils.addFilesToTaskInputs(inputs, sourceSet.proto)
+          Utils.addFilesToTaskInputs(project, inputs, sourceSet.proto)
           ProtobufSourceDirectorySet protoSrcDirSet = sourceSet.proto
           protoSrcDirSet.srcDirs.each { srcDir ->
             include srcDir
@@ -315,7 +315,7 @@ class ProtobufPlugin implements Plugin<Project> {
               project.fileTree(getExtractedProtosDir(sourceSet.name)) {
                 include "**/*.proto"
               }
-          Utils.addFilesToTaskInputs(inputs, extractedProtoSources)
+          Utils.addFilesToTaskInputs(project, inputs, extractedProtoSources)
           include extractedProtoSources.dir
         }
       }

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -32,6 +32,7 @@ import com.google.common.base.Preconditions
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskInputs
 import org.gradle.plugins.ide.idea.GenerateIdeaModule
@@ -95,8 +96,12 @@ class Utils {
     return "compile" + GUtil.toCamelCase(variantName) + "Kotlin"
   }
 
-  static void addFilesToTaskInputs(TaskInputs inputs, Object files) {
-    inputs.files(files).skipWhenEmpty()
+  static void addFilesToTaskInputs(Project project, TaskInputs inputs, Object files) {
+    if (compareGradleVersion(project, "4.0") >= 0) {
+      inputs.files(files).skipWhenEmpty().withPathSensitivity(PathSensitivity.RELATIVE)
+    } else {
+      inputs.files(files).skipWhenEmpty()
+    }
   }
 
   /**


### PR DESCRIPTION
By default the absolute path sensitivity is considered which means that
the task cannot be cached on a remote build server.