### PR TITLE
Use Relative Sensitivity for GenerateProtoTask, use name only sensitivity for classpath.

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -31,7 +31,6 @@ package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
-
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Named
@@ -43,6 +42,7 @@ import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.ConfigureUtil
@@ -336,7 +336,7 @@ public class GenerateProtoTask extends DefaultTask {
     includeDirs.add(dir)
     // Register all files under the directory as input so that Gradle will check their changes for
     // incremental build
-    inputs.dir(dir)
+    inputs.dir(dir).withPathSensitivity(PathSensitivity.RELATIVE)
   }
 
   /**
@@ -346,7 +346,7 @@ public class GenerateProtoTask extends DefaultTask {
     checkCanConfig()
     sourceFiles.from(files)
     // Register the files as input so that Gradle will check their changes for incremental build
-    inputs.files(files)
+    inputs.files(files).withPathSensitivity(PathSensitivity.RELATIVE)
   }
 
   /**

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -330,7 +330,7 @@ class ProtobufPlugin implements Plugin<Project> {
           description = "Extracts proto files/dependencies specified by 'protobuf' configuration"
           destDir = getExtractedProtosDir(sourceSetName) as File
           inputs.files(project.configurations[Utils.getConfigName(sourceSetName, 'protobuf')])
-                  .withPathSensitivity(PathSensitivity.RELATIVE)
+                  .withPathSensitivity(PathSensitivity.NAME_ONLY)
           isTest = Utils.isTest(sourceSetName)
         }
       }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -329,7 +329,8 @@ class ProtobufPlugin implements Plugin<Project> {
         task = project.tasks.create(extractProtosTaskName, ProtobufExtract) {
           description = "Extracts proto files/dependencies specified by 'protobuf' configuration"
           destDir = getExtractedProtosDir(sourceSetName) as File
-          inputs.files project.configurations[Utils.getConfigName(sourceSetName, 'protobuf')]
+          inputs.files(project.configurations[Utils.getConfigName(sourceSetName, 'protobuf')])
+                  .withPathSensitivity(PathSensitivity.RELATIVE)
           isTest = Utils.isTest(sourceSetName)
         }
       }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -30,7 +30,6 @@
 package com.google.protobuf.gradle
 
 import com.google.common.collect.ImmutableList
-
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -42,6 +41,7 @@ import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.AppliedPlugin
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet
 
 import javax.inject.Inject
@@ -359,6 +359,7 @@ class ProtobufPlugin implements Plugin<Project> {
           destDir = getExtractedIncludeProtosDir(sourceSetOrVariantName) as File
           inputs.files (compileClasspathConfiguration
             ?: project.configurations[Utils.getConfigName(sourceSetOrVariantName, 'compile')])
+                  .withPathSensitivity(PathSensitivity.NAME_ONLY)
 
           // TL; DR: Make protos in 'test' sourceSet able to import protos from the 'main'
           // sourceSet.  Sub-configurations, e.g., 'testCompile' that extends 'compile', don't
@@ -379,7 +380,8 @@ class ProtobufPlugin implements Plugin<Project> {
             // 'resources' of the output of 'main', in which the source protos are placed.  This is
             // nicer than the ad-hoc solution that Android has, because it works for any extended
             // configuration, not just 'testCompile'.
-            inputs.files getSourceSets()[sourceSetOrVariantName].compileClasspath
+            inputs.files (getSourceSets()[sourceSetOrVariantName].compileClasspath)
+                    .withPathSensitivity(PathSensitivity.NAME_ONLY)
           }
           isTest = Utils.isTest(sourceSetOrVariantName)
         }


### PR DESCRIPTION
Using absolute sensitivity does not allow this task output to be re-used
across different machines.

Classpath jars and files can be located in different parts of the
filesystem relative to the current working directory so the task output
is not cacheable unless we use NAME_ONLY sensitivity.