### PR TITLE
Gradle build scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
     - GRADLE_OPTS="-Xms128m"
 
 script:
-  - ./gradlew clean assemble test --tests com.google.protobuf.gradle.ProtobufJavaPluginTest --stacktrace
-  - ./gradlew test --tests com.google.protobuf.gradle.ProtobufKotlinDslPluginTest --stacktrace
-  - ./gradlew test --tests com.google.protobuf.gradle.ProtobufAndroidPluginTest --stacktrace
-  - ./gradlew test --tests com.google.protobuf.gradle.AndroidProjectDetectionTest --stacktrace
+  - ./gradlew clean assemble test --tests com.google.protobuf.gradle.ProtobufJavaPluginTest --stacktrace --scan
+  - ./gradlew test --tests com.google.protobuf.gradle.ProtobufKotlinDslPluginTest --stacktrace --scan
+  - ./gradlew test --tests com.google.protobuf.gradle.ProtobufAndroidPluginTest --stacktrace --scan
+  - ./gradlew test --tests com.google.protobuf.gradle.AndroidProjectDetectionTest --stacktrace --scan
   - ./gradlew codenarcMain || (cat ./build/reports/codenarc/main.txt && false)
   - ./gradlew codenarcTest || (cat ./build/reports/codenarc/test.txt && false)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,17 @@
+plugins {
+    id 'com.gradle.build-scan' version '2.1'
+    id 'codenarc'
+    id 'idea'
+    id 'eclipse'
+    id 'groovy'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.10'
+    id 'maven'
+    id 'signing'
+    id 'com.jfrog.bintray' version '1.6'
+    id 'com.gradle.plugin-publish' version '0.9.7'
+    id 'com.github.ben-manes.versions' version '0.12.0'
+}
+
 println """\
 Welcome to Gradle $gradle.gradleVersion - http://www.gradle.org
 Gradle home is set to: $gradle.gradleHomeDir
@@ -7,34 +21,15 @@ Base directory: $projectDir
 Running script ${relativePath(buildFile)}
 """
 
-apply plugin: 'codenarc'
-apply plugin: 'idea'
-apply plugin: 'eclipse'
-apply plugin: 'groovy'
-apply plugin: 'kotlin'
-apply plugin: 'maven'
-apply plugin: 'signing'
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'com.gradle.plugin-publish'
-apply plugin: 'com.github.ben-manes.versions'
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    apply from: 'gradle/build-scans.gradle'
+}
 
 group = 'com.google.protobuf'
 version = '0.8.9-SNAPSHOT'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-
-buildscript {
-    repositories {
-        maven { url "https://plugins.gradle.org/m2/" } // Mirrors jcenter() and mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
-        classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.12.0"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.10"
-    }
-}
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -1,0 +1,33 @@
+def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/protobuf/gradle-scans-license-agree.txt")
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.PROTOBUF_GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.PROTOBUF_GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `PROTOBUF_GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

## Notes
- plugin definitions were update to use the `plugins` block instead of `buildscript`.
- `plugins` block moved to the top of the build file.
- acceptance of scans terms of service is conditional on developer's machine but required on CI.