### PR TITLE
Do not use deprecated Android Plugin API when new API is available

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -440,6 +440,13 @@ class ProtobufPlugin implements Plugin<Project> {
           project.protobuf.generateProtoTasks.ofVariant(variant.name).each { GenerateProtoTask genProtoTask ->
             // unit test variants do not implement registerJavaGeneratingTask
             Task javaCompileTask = variant.javaCompile
+            if (variant.hasProperty('javaCompileProvider')) {
+              // Android 3.3.0+
+              javaCompileTask = variant.javaCompileProvider.get()
+            } else {
+              // Older Android
+              javaCompileTask = variant.javaCompile
+            }
             if (javaCompileTask != null) {
               linkGenerateProtoTasksToTask(javaCompileTask, genProtoTask)
             }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -11,7 +11,7 @@ import spock.lang.Specification
  */
 class ProtobufAndroidPluginTest extends Specification {
   // TODO(zhangkun83): restore 3.0/2.2.0 once https://github.com/gradle/gradle/issues/8158 is resolved
-  private static final List<String> GRADLE_VERSION = [/* "3.0", */ "4.2", "4.3", "5.1"]
+  private static final List<String> GRADLE_VERSION = [/* "3.1", */ "4.2", "4.3", "5.1"]
   private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "2.3.0", "2.3.0", "3.1.0"]
 
   void "testProjectAndroid should be successfully executed (java only)"() {


### PR DESCRIPTION
Resolves #295 

Partially tested with Gradle 3.1 / Android 2.2.0, with Android tests passing but Kotlin failing with unrelated issue. Won't compile with Gradle 3.0 because `PathSensitivity` (added in #293) requires at least 3.1.
