### PR TITLE
add comments to settings.kts in ktdsl example

### DIFF
--- a/examples/exampleKotlinDslProject/settings.gradle.kts
+++ b/examples/exampleKotlinDslProject/settings.gradle.kts
@@ -3,6 +3,9 @@ pluginManagement{
         mavenLocal()
         maven("https://plugins.gradle.org/m2/")
     }
+    // The resolutionStrategy only needs to be configured for 
+    // local plugin development, specifically when using the 
+    // mavenLocal repository.
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "com.google.protobuf") {


### PR DESCRIPTION
Added comments to `setttings.kts` in kotlin script example. This is to prevent users from assuming they need to configure a `resolutionStrategy` in order to use the plugin with kotlin dsl