### PR TITLE
Do not call variant.javaCompile for android 3.3.0+ to get rid of Android API warning

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -433,7 +433,7 @@ class ProtobufPlugin implements Plugin<Project> {
         project.android.unitTestVariants.each { variant ->
           project.protobuf.generateProtoTasks.ofVariant(variant.name).each { GenerateProtoTask genProtoTask ->
             // unit test variants do not implement registerJavaGeneratingTask
-            Task javaCompileTask = variant.javaCompile
+            Task javaCompileTask
             if (variant.hasProperty('javaCompileProvider')) {
               // Android 3.3.0+
               javaCompileTask = variant.javaCompileProvider.get()


### PR DESCRIPTION
Resolves #295

I believe this is just something forgotten in #305. Thanks @kcoppock for point this out in https://github.com/google/protobuf-gradle-plugin/issues/295#issuecomment-502864312.