### PR TITLE
Use guava 28.1-android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compileOnly localGroovy()
     compileOnly "org.gradle:gradle-kotlin-dsl:1.0.4"
 
-    compile 'com.google.guava:guava:18.0'
+    compile 'com.google.guava:guava:28.1-android'
     compile 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
     compile 'commons-lang:commons-lang:2.6'
 


### PR DESCRIPTION
Ideally guava should be shaded. However, the first step would be to upgrade to modern guava so Gradle plugins don't break, for example: findbugs, spotbugs