### PR TITLE
Bump Guava version and os_detector_plugin version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-26.0.1
     - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compileOnly localGroovy()
     compileOnly "org.gradle:gradle-kotlin-dsl:1.0.4"
 
-    compile 'com.google.guava:guava:18.0'
+    compile 'com.google.guava:guava:27.0.1-jre'
     compile 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
     compile 'commons-lang:commons-lang:2.6'
 

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -10,8 +10,8 @@ import spock.lang.Specification
  * Verify android projects are identified correctly
  */
 class AndroidProjectDetectionTest extends Specification {
-  private static final List<String> GRADLE_VERSION = [/* "3.0", */ "4.2", "4.3", "5.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "2.3.0", "2.3.0", "3.1.0"]
+  private static final List<String> GRADLE_VERSION = [/* "3.0", */ "4.10.1", "5.1.1", "5.4.1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "3.3.0", "3.4.0", "3.5.0"]
 
   static void appendUtilIsAndroidProjectCheckTask(File buildFile, boolean assertResult) {
     buildFile << """

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -11,8 +11,8 @@ import spock.lang.Specification
  */
 class ProtobufAndroidPluginTest extends Specification {
   // TODO(zhangkun83): restore 3.0/2.2.0 once https://github.com/gradle/gradle/issues/8158 is resolved
-  private static final List<String> GRADLE_VERSION = [/* "3.1", */ "4.2", "4.3", "5.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "2.3.0", "2.3.0", "3.1.0"]
+  private static final List<String> GRADLE_VERSION = [/* "3.0", */ "4.10.1", "5.1.1", "5.4.1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "3.3.0", "3.4.0", "3.5.0"]
 
   void "testProjectAndroid should be successfully executed (java only)"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
  * Unit tests for kotlin dsl extensions.
  */
 class ProtobufKotlinDslPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSIONS = ["4.10", "5.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.4", "5.6"]
 
   void "testProjectKotlinDsl should be successfully executed (java-only project)"() {
     given: "project from testProjectKotlinDslBase"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -43,20 +43,10 @@ final class ProtobufPluginTestHelper {
             dependencies {
     """
 
-    //android gradle plugin needs guava 22 so check for that before including guava from pluginClasspath
     pluginClasspath.each { dependency ->
-        if (dependency.contains("guava")) {
-            buildFile << """
-                if (!project.hasProperty("androidPluginVersion") ||
-                    !project.findProperty("androidPluginVersion").startsWith("3.")) {
-                    classpath files($dependency)
-                }
-            """
-        } else {
-            buildFile << """
-                classpath files($dependency)
-            """
-        }
+        buildFile << """
+            classpath files($dependency)
+        """
     }
 
     buildFile << """
@@ -87,10 +77,6 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:\$androidPluginVersion"
-        if (androidPluginVersion.startsWith("3.")) {
-            //agp 3.+ needs guava 22 but the protobuf project uses a lower version
-            classpath 'com.google.guava:guava:22.0'
-        }
     }
 }
 """

--- a/testProjectKotlinDslBase/build.gradle.kts
+++ b/testProjectKotlinDslBase/build.gradle.kts
@@ -10,14 +10,7 @@ buildscript {
         File("$projectDir/../../createClasspathManifest/plugin-classpath.txt")
             .readLines()
             .forEach { classpathEntry ->
-                if("guava" in classpathEntry){
-                    if (!project.hasProperty("androidPluginVersion") ||
-                        !project.findProperty("androidPluginVersion").toString().startsWith("3.")) {
-                        classpath(files(classpathEntry))
-                    }
-                } else {
-                    classpath(files(classpathEntry))
-                }
+                classpath(files(classpathEntry))
             }
     }
 }


### PR DESCRIPTION
This PR aims to upgrade the plugin's Guava version, which is currently using Guava 18.0.

After investigation, we intend to upgrade to Guava 27.0.1-jre (Guava 27.1-android, which is [used in latest Gradle](https://github.com/gradle/gradle/blob/v5.6.2/gradle/dependencies.gradle#L57) can cause issues when working with Android plugin as some methods do not exist, such as `ImmutableList.toImmutableList()`). 

Older versions of Android plugin depends on some Guava methods that have been removed in higher version Guava (such as [CharMatcher. JAVA_LETTER_OR_DIGIT](https://guava.dev/releases/23.6-jre/api/docs/com/google/common/base/CharMatcher.html#JAVA_LETTER_OR_DIGIT)).

The minimum supported version of Android plugin would be bumped to `3.3.0` and the minimum supported version of Gradle would be bumped to `4.10.1`.

Users may still be able to apply this plugin with old versions of Android plugin by explicitly excluding Guava dependency in buildscript classpath.