### PR TITLE
Disable GradleRunner debug mode for Android tests

### DIFF
--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -108,7 +108,6 @@ buildscript {
        // set android build cache to avoid using home directory on travis CI.
        "-Pandroid.buildCacheDir=$localBuildCache",
        fullPathTask,
-       "-x", "lint", // linter causes .withDebug(true) to fail
        "--stacktrace")
        .withGradleVersion(gradleVersion)
        .forwardStdOutput(new OutputStreamWriter(System.out))

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -113,7 +113,9 @@ buildscript {
        .withGradleVersion(gradleVersion)
        .forwardStdOutput(new OutputStreamWriter(System.out))
        .forwardStdError(new OutputStreamWriter(System.err))
-       .withDebug(true)
+    // Enabling debug causes the test to fail with Android plugin version 3.3.0+.
+    // See https://docs.gradle.org/current/javadoc/org/gradle/testkit/runner/GradleRunner.html#isDebug--
+    // .withDebug(true)
        .build()
   }
 


### PR DESCRIPTION
Tests fail (e.g., https://travis-ci.org/google/protobuf-gradle-plugin/builds/598510181?utm_source=github_status&utm_medium=notification) with Android plugin version 3.3.0+ with `withDebug(true)` invoked on `GradleRunner`.

Disable debug mode for GradleRunner since we are adding test coverage for newer versions of Android plugin.