### PR TITLE
Upgrade Gradle/Android plugin versions being covered in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-26.0.1
     - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -10,8 +10,8 @@ import spock.lang.Specification
  * Verify android projects are identified correctly
  */
 class AndroidProjectDetectionTest extends Specification {
-  private static final List<String> GRADLE_VERSION = [/* "3.0", */ "4.2", "4.3", "5.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "2.3.0", "2.3.0", "3.1.0"]
+  private static final List<String> GRADLE_VERSION = [/* "3.0", */ "5.0", "5.1.1", "5.4.1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "3.3.0", "3.4.0", "3.5.0"]
 
   static void appendUtilIsAndroidProjectCheckTask(File buildFile, boolean assertResult) {
     buildFile << """

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -10,8 +10,9 @@ import spock.lang.Specification
  * Verify android projects are identified correctly
  */
 class AndroidProjectDetectionTest extends Specification {
-  private static final List<String> GRADLE_VERSION = [/* "3.0", */ "5.0", "5.1.1", "5.4.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "3.3.0", "3.4.0", "3.5.0"]
+  // Current supported version is Android plugin 3.3.0+.
+  private static final List<String> GRADLE_VERSION = ["5.0", "5.1.1", "5.4.1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.3.0", "3.4.0", "3.5.0"]
 
   static void appendUtilIsAndroidProjectCheckTask(File buildFile, boolean assertResult) {
     buildFile << """

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -10,9 +10,9 @@ import spock.lang.Specification
  * Unit tests for android related functionality.
  */
 class ProtobufAndroidPluginTest extends Specification {
-  // TODO(zhangkun83): restore 3.0/2.2.0 once https://github.com/gradle/gradle/issues/8158 is resolved
-  private static final List<String> GRADLE_VERSION = [/* "3.1", */ "5.0", "5.1.1", "5.4.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "3.3.0", "3.4.0", "3.5.0"]
+  // Current supported version is Android plugin 3.3.0+.
+  private static final List<String> GRADLE_VERSION = ["5.0", "5.1.1", "5.4.1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.3.0", "3.4.0", "3.5.0"]
 
   void "testProjectAndroid should be successfully executed (java only)"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -11,8 +11,8 @@ import spock.lang.Specification
  */
 class ProtobufAndroidPluginTest extends Specification {
   // TODO(zhangkun83): restore 3.0/2.2.0 once https://github.com/gradle/gradle/issues/8158 is resolved
-  private static final List<String> GRADLE_VERSION = [/* "3.1", */ "4.2", "4.3", "5.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "2.3.0", "2.3.0", "3.1.0"]
+  private static final List<String> GRADLE_VERSION = [/* "3.1", */ "5.0", "5.1.1", "5.4.1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = [/* "2.2.0", */ "3.3.0", "3.4.0", "3.5.0"]
 
   void "testProjectAndroid should be successfully executed (java only)"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Specification
  */
 class ProtobufJavaPluginTest extends Specification {
   // TODO(zhangkun83): restore 3.0 once https://github.com/gradle/gradle/issues/8158 is resolved
-  private static final List<String> GRADLE_VERSIONS = [/* "3.0",*/ "4.0", "4.3", "5.1"]
+  private static final List<String> GRADLE_VERSIONS = [/* "3.0",*/ "5.0", "5.1", "5.4", "5.6"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
     given: "a basic project with java and com.google.protobuf"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -12,8 +12,8 @@ import spock.lang.Specification
  * Unit tests for normal java and kotlin functionality.
  */
 class ProtobufJavaPluginTest extends Specification {
-  // TODO(zhangkun83): restore 3.0 once https://github.com/gradle/gradle/issues/8158 is resolved
-  private static final List<String> GRADLE_VERSIONS = [/* "3.0",*/ "5.0", "5.1", "5.4", "5.6"]
+  // Current supported version is Gradle 5+.
+  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
     given: "a basic project with java and com.google.protobuf"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -9,6 +9,7 @@ import spock.lang.Specification
  * Unit tests for kotlin dsl extensions.
  */
 class ProtobufKotlinDslPluginTest extends Specification {
+  // Current supported version is Gradle 5+.
   private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6"]
 
   void "testProjectKotlinDsl should be successfully executed (java-only project)"() {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -9,7 +9,7 @@ import spock.lang.Specification
  * Unit tests for kotlin dsl extensions.
  */
 class ProtobufKotlinDslPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSIONS = ["4.10", "5.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6"]
 
   void "testProjectKotlinDsl should be successfully executed (java-only project)"() {
     given: "project from testProjectKotlinDslBase"


### PR DESCRIPTION
We are upgrading Guava version in the plugin, which will break the compatibility with old versions of Android plugin (as they use some Guava APIs that have been removed in newer versions).

Our tests did not have coverage for newer versions of Gradle and Android plugin, which is not appropriate.

I've been experimenting with version compatibility of Gradle, Android plugin and Guava. We plan to upgrade Guava to `27.0.1-jre`. Android tests would be broken for Android plugin older than version `3.3.0` (which requires Gradle `4.10.1+`). Kotlin DSL test would also be broken for Gradle version older than `4.10.1` (there are [a bunch of fixes for Kotlin DSL](https://github.com/gradle/kotlin-dsl-samples/releases/tag/v1.0-RC6) getting in since Gradle 4.10.1). 

Therefore, it is reasonable to make a decision to support only Gradle 5+ and Android 3.3.0 (they were released around the same time as Guava 27.0.1-jre) and encourage users to migrate to newer versions of those. 


---------------------------

TODO: we can clean up code for compatibility purposes such as https://github.com/google/protobuf-gradle-plugin/blob/15faef201d288bbe164b9e27d864f4f12d283eb0/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L184-L190