### PR TITLE
Bump Guava version to 27.0.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compileOnly localGroovy()
     compileOnly "org.gradle:gradle-kotlin-dsl:1.0.4"
 
-    compile 'com.google.guava:guava:18.0'
+    compile 'com.google.guava:guava:27.0.1-jre'
     compile 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
     compile 'commons-lang:commons-lang:2.6'
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -43,20 +43,10 @@ final class ProtobufPluginTestHelper {
             dependencies {
     """
 
-    //android gradle plugin needs guava 22 so check for that before including guava from pluginClasspath
     pluginClasspath.each { dependency ->
-        if (dependency.contains("guava")) {
-            buildFile << """
-                if (!project.hasProperty("androidPluginVersion") ||
-                    !project.findProperty("androidPluginVersion").startsWith("3.")) {
-                    classpath files($dependency)
-                }
-            """
-        } else {
-            buildFile << """
-                classpath files($dependency)
-            """
-        }
+      buildFile << """
+          classpath files($dependency)
+      """
     }
 
     buildFile << """
@@ -87,10 +77,6 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:\$androidPluginVersion"
-        if (androidPluginVersion.startsWith("3.")) {
-            //agp 3.+ needs guava 22 but the protobuf project uses a lower version
-            classpath 'com.google.guava:guava:22.0'
-        }
     }
 }
 """

--- a/testProjectKotlinDslBase/build.gradle.kts
+++ b/testProjectKotlinDslBase/build.gradle.kts
@@ -10,14 +10,7 @@ buildscript {
         File("$projectDir/../../createClasspathManifest/plugin-classpath.txt")
             .readLines()
             .forEach { classpathEntry ->
-                if("guava" in classpathEntry){
-                    if (!project.hasProperty("androidPluginVersion") ||
-                        !project.findProperty("androidPluginVersion").toString().startsWith("3.")) {
-                        classpath(files(classpathEntry))
-                    }
-                } else {
-                    classpath(files(classpathEntry))
-                }
+                classpath(files(classpathEntry))
             }
     }
 }


### PR DESCRIPTION
To be merged after #345 getting in.


Requested by #247, although the issue mentioned there is not caused by Guava dependency in this plugin (see https://github.com/google/protobuf-gradle-plugin/issues/247#issuecomment-543233638).