### PR TITLE
for generateProto, delete the output directory before calling protoc

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -451,6 +451,7 @@ public class GenerateProtoTask extends DefaultTask {
 
     [builtins, plugins]*.each { plugin ->
       File outputDir = new File(getOutputDir(plugin))
+      outputDir.deleteDir()
       outputDir.mkdirs()
     }
 


### PR DESCRIPTION
Fix for #331 / #332