### PR TITLE
Delete code for Android pre-3.3.0 support

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -433,14 +433,7 @@ class ProtobufPlugin implements Plugin<Project> {
         project.android.unitTestVariants.each { variant ->
           project.protobuf.generateProtoTasks.ofVariant(variant.name).each { GenerateProtoTask genProtoTask ->
             // unit test variants do not implement registerJavaGeneratingTask
-            Task javaCompileTask
-            if (variant.hasProperty('javaCompileProvider')) {
-              // Android 3.3.0+
-              javaCompileTask = variant.javaCompileProvider.get()
-            } else {
-              // Older Android
-              javaCompileTask = variant.javaCompile
-            }
+            Task javaCompileTask = variant.javaCompileProvider.get()
             if (javaCompileTask != null) {
               linkGenerateProtoTasksToTask(javaCompileTask, genProtoTask)
             }

--- a/testProjectAndroidBase/build_base.gradle
+++ b/testProjectAndroidBase/build_base.gradle
@@ -115,7 +115,7 @@ dependencies {
 }
 
 def assertJavaCompileHasProtoGeneratedDir(Object variant, Collection<String> codegenPlugins) {
-  rootProject.assertJavaCompileHasProtoGeneratedDir(project, variant.name, variant.javaCompile, codegenPlugins)
+  rootProject.assertJavaCompileHasProtoGeneratedDir(project, variant.name, variant.javaCompileProvider.get(), codegenPlugins)
 }
 
 afterEvaluate {
@@ -123,7 +123,7 @@ afterEvaluate {
   // Android plugin, and would do nothing with our setup. We make 'test' to
   // trigger the "androidTest" Java compile tasks.
   android.testVariants.each { testVariant ->
-    test.dependsOn testVariant.javaCompile
+    test.dependsOn testVariant.javaCompileProvider
   }
 
   test.doLast {


### PR DESCRIPTION
#345 dropped the support for pre-3.3.0. This deletes the code for good.