### PR TITLE
Reduce severity of plugin already applied message

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -91,7 +91,7 @@ class ProtobufPlugin implements Plugin<Project> {
         // throw an Exception to alert the user of this configuration issue.
         Action<? super AppliedPlugin> applyWithPrerequisitePlugin = { prerequisitePlugin ->
           if (wasApplied) {
-            project.logger.warn('The com.google.protobuf plugin was already applied to the project: ' + project.path
+            project.logger.info('The com.google.protobuf plugin was already applied to the project: ' + project.path
                 + ' and will not be applied again after plugin: ' + prerequisitePlugin.id)
           } else {
             wasApplied = true


### PR DESCRIPTION
Fixes #354

The message

```
The com.google.protobuf plugin was already applied to the project...
```

is shown in Android projects with correctly-applied plugins. Since the message is not actionable, this PR reduces the logged severity from `warn` to `info`.