### PR TITLE
Extend coverage of usage with Java and Kotlin plugins to Gradle 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.12.0"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.10"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
     }
 }
 
@@ -88,7 +88,7 @@ dependencies {
 
     // This kotlin version needs to be compatible with the 
     // android plugin being used in the test runtime.
-    testProjectRuntime "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11"
+    testProjectRuntime "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
 
     // Add android plugin to the test classpath, so that we can jump into class definitions,
     // read their sources, set break points, etc while debugging android unit tests.

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -28,7 +28,7 @@ class AndroidProjectDetectionTest extends Specification {
   }
 
   @Unroll
-  void "test Utils.isAndroidProject positively detects android project [android #androidPluginVersion, gradle #gradleVersion]"() {
+  void "test succeeds on android project [android #agpVersion, gradle #gradleVersion]"() {
     given: "a project with android plugin"
     File mainProjectDir = ProtobufPluginTestHelper.projectBuilder("singleModuleAndroidProject")
        .copyDirs('testProjectAndroid', 'testProjectAndroidBare')
@@ -38,7 +38,7 @@ class AndroidProjectDetectionTest extends Specification {
     when: "checkForAndroidPlugin task evaluates Utils.isAndroidProject"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-       androidPluginVersion,
+       agpVersion,
        gradleVersion,
        "checkForAndroidPlugin"
     )
@@ -47,7 +47,7 @@ class AndroidProjectDetectionTest extends Specification {
     assert result.task(":checkForAndroidPlugin").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ANDROID_PLUGIN_VERSION
+    agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
   }
 
@@ -55,7 +55,7 @@ class AndroidProjectDetectionTest extends Specification {
    * Failing test case for https://github.com/google/protobuf-gradle-plugin/issues/236
    */
   @Unroll
-  void "test Utils.isAndroidProject returns false on sub project of android project [android #androidPluginVersion, gradle #gradleVersion]"() {
+  void "test fails on sub project of android project [android #agpVersion, gradle #gradleVersion]"() {
     given: "an android root project and java sub project"
     File subProjectStaging = ProtobufPluginTestHelper.projectBuilder('subModuleTestProjectLite')
        .copyDirs('testProjectLite')
@@ -70,7 +70,7 @@ class AndroidProjectDetectionTest extends Specification {
     when: "checkForAndroidPlugin task evaluates Utils.isAndroidProject"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-       androidPluginVersion,
+            agpVersion,
        gradleVersion,
        "checkForAndroidPlugin"
     )
@@ -80,7 +80,7 @@ class AndroidProjectDetectionTest extends Specification {
     assert result.task(":subModuleTestProjectLite:checkForAndroidPlugin").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ANDROID_PLUGIN_VERSION
+    agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
   }
 }

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -5,6 +5,7 @@ import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidPr
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Verify android projects are identified correctly
@@ -26,7 +27,8 @@ class AndroidProjectDetectionTest extends Specification {
 """
   }
 
-  void "test Utils.isAndroidProject positively detects android project"() {
+  @Unroll
+  void "test Utils.isAndroidProject positively detects android project [android #androidPluginVersion, gradle #gradleVersion]"() {
     given: "a project with android plugin"
     File mainProjectDir = ProtobufPluginTestHelper.projectBuilder("singleModuleAndroidProject")
        .copyDirs('testProjectAndroid', 'testProjectAndroidBare')
@@ -52,7 +54,8 @@ class AndroidProjectDetectionTest extends Specification {
   /**
    * Failing test case for https://github.com/google/protobuf-gradle-plugin/issues/236
    */
-  void "test Utils.isAndroidProject returns false on sub project of android project"() {
+  @Unroll
+  void "test Utils.isAndroidProject returns false on sub project of android project [android #androidPluginVersion, gradle #gradleVersion]"() {
     given: "an android root project and java sub project"
     File subProjectStaging = ProtobufPluginTestHelper.projectBuilder('subModuleTestProjectLite')
        .copyDirs('testProjectLite')

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -16,7 +16,7 @@ class ProtobufAndroidPluginTest extends Specification {
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.3.0", "3.4.0", "3.5.0"]
 
   @Unroll
-  void "testProjectAndroid should be successfully executed (java only) [android #androidPluginVersion, gradle #gradleVersion]"() {
+  void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"
     File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
         .copyDirs('testProjectBase', 'testProject')
@@ -33,7 +33,7 @@ class ProtobufAndroidPluginTest extends Specification {
     when: "build is invoked"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-       androidPluginVersion,
+       agpVersion,
        gradleVersion,
        "testProjectAndroid:build"
     )
@@ -42,12 +42,12 @@ class ProtobufAndroidPluginTest extends Specification {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ANDROID_PLUGIN_VERSION
+    agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
   }
 
   @Unroll
-  void "testProjectAndroidKotlin should be successfully executed (kotlin only) [android #androidPluginVersion, gradle #gradleVersion]"() {
+  void "testProjectAndroidKotlin should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"
     File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
         .copyDirs('testProjectBase', 'testProject')
@@ -64,7 +64,7 @@ class ProtobufAndroidPluginTest extends Specification {
     when: "build is invoked"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-       androidPluginVersion,
+       agpVersion,
        gradleVersion,
        "testProjectAndroid:build"
     )
@@ -73,7 +73,7 @@ class ProtobufAndroidPluginTest extends Specification {
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
 
     where:
-    androidPluginVersion << ANDROID_PLUGIN_VERSION
+    agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
   }
 }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -5,6 +5,7 @@ import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidPr
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Unit tests for android related functionality.
@@ -14,7 +15,8 @@ class ProtobufAndroidPluginTest extends Specification {
   private static final List<String> GRADLE_VERSION = ["5.0", "5.1.1", "5.4.1"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.3.0", "3.4.0", "3.5.0"]
 
-  void "testProjectAndroid should be successfully executed (java only)"() {
+  @Unroll
+  void "testProjectAndroid should be successfully executed (java only) [android #androidPluginVersion, gradle #gradleVersion]"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"
     File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
         .copyDirs('testProjectBase', 'testProject')
@@ -44,7 +46,8 @@ class ProtobufAndroidPluginTest extends Specification {
     gradleVersion << GRADLE_VERSION
   }
 
-  void "testProjectAndroidKotlin should be successfully executed (kotlin only)"() {
+  @Unroll
+  void "testProjectAndroidKotlin should be successfully executed (kotlin only) [android #androidPluginVersion, gradle #gradleVersion]"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"
     File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
         .copyDirs('testProjectBase', 'testProject')

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Unroll
  */
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6"]
+  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6", "6.0"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
     given: "a basic project with java and com.google.protobuf"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -7,6 +7,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Unit tests for normal java and kotlin functionality.
@@ -49,7 +50,8 @@ class ProtobufJavaPluginTest extends Specification {
     assert project.tasks.extractMain2Proto instanceof ProtobufExtract
   }
 
-  void "testProject should be successfully executed (java-only project)"() {
+  @Unroll
+  void "testProject should be successfully executed (java-only project) [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
         .copyDirs('testProjectBase', 'testProject')
@@ -73,7 +75,8 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProjectBuildTimeProto should be successfully executed"() {
+  @Unroll
+  void "testProjectBuildTimeProto should be successfully executed [gradle #gradleVersion]"() {
     given: "project from testProjectGeneratedProto"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectBuildTimeProto')
             .copyDirs('testProjectBuildTimeProto')
@@ -96,7 +99,8 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProjectKotlin should be successfully executed (kotlin-only project)"() {
+  @Unroll
+  void "testProjectKotlin should be successfully executed (kotlin-only project) [gradle #gradleVersion]"() {
     given: "project from testProjectKotlin overlaid on testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectKotlin')
         .copyDirs('testProjectBase', 'testProjectKotlin')
@@ -118,7 +122,8 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProjectJavaAndKotlin should be successfully executed (java+kotlin project)"() {
+  @Unroll
+  void "testProjectJavaAndKotlin should be successfully executed (java+kotlin project) [gradle #gradleVersion]"() {
     given: "project from testProjecJavaAndKotlin overlaid on testProjectKotlin, testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectJavaAndKotlin')
         .copyDirs('testProjectBase', 'testProject', 'testProjectKotlin', 'testProjectJavaAndKotlin')
@@ -140,7 +145,8 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProjectLite should be successfully executed"() {
+  @Unroll
+  void "testProjectLite should be successfully executed [gradle #gradleVersion]"() {
     given: "project from testProjectLite"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectLite')
         .copyDirs('testProjectBase', 'testProjectLite')
@@ -163,7 +169,8 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProjectDependent should be successfully executed"() {
+  @Unroll
+  void "testProjectDependent should be successfully executed [gradle #gradleVersion]"() {
     given: "project from testProject & testProjectDependent"
     File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
         .copyDirs('testProjectBase', 'testProject')
@@ -193,7 +200,8 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProjectCustomProtoDir should be successfully executed"() {
+  @Unroll
+  void "testProjectCustomProtoDir should be successfully executed [gradle #gradleVersion]"() {
     given: "project from testProjectCustomProtoDir"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectCustomProtoDir')
         .copyDirs('testProjectCustomProtoDir')
@@ -216,7 +224,8 @@ class ProtobufJavaPluginTest extends Specification {
     gradleVersion << GRADLE_VERSIONS
   }
 
-  void "testProject proto and generated output directories should be added to intellij"() {
+  @Unroll
+  void "testProject proto and generated output directories should be added to intellij [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testIdea')
         .copyDirs('testProjectBase', 'testProject')

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -11,7 +11,7 @@ import spock.lang.Unroll
  */
 class ProtobufKotlinDslPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6"]
+  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6", "6.0"]
 
   @Unroll
   void "testProjectKotlinDsl should be successfully executed (java-only project) [gradle #gradleVersion]"() {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -4,6 +4,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Unit tests for kotlin dsl extensions.
@@ -12,7 +13,8 @@ class ProtobufKotlinDslPluginTest extends Specification {
   // Current supported version is Gradle 5+.
   private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6"]
 
-  void "testProjectKotlinDsl should be successfully executed (java-only project)"() {
+  @Unroll
+  void "testProjectKotlinDsl should be successfully executed (java-only project) [gradle #gradleVersion]"() {
     given: "project from testProjectKotlinDslBase"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectKotlinDsl')
         .copyDirs('testProjectKotlinDslBase')


### PR DESCRIPTION
This PR extends the existing tests to cover the usage of the Protobuf plugin with the Java and Kotlin plugins with Gradle 6.0.

No changes were required to the Protobuf plugin. The dependency to the Kotlin Gradle Plugin had to be bumped from 1.3.10 to 1.3.20.