### PR TITLE
Use separate configuration for extracting included proto from dependencies

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -397,6 +397,12 @@ class ProtobufPlugin implements Plugin<Project> {
               inputFiles.from getSourceSets()['main'].proto
               inputFiles.from testedCompileClasspathConfiguration ?: project.configurations['compile']
             }
+          } else {
+            // In Java projects, the compileClasspath of the 'test' sourceSet includes all the
+            // 'resources' of the output of 'main', in which the source protos are placed.  This is
+            // nicer than the ad-hoc solution that Android has, because it works for any extended
+            // configuration, not just 'testCompile'.
+            inputFiles.from getSourceSets()[sourceSetOrVariantName].compileClasspath
           }
           isTest = Utils.isTest(sourceSetOrVariantName)
         }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -173,12 +173,12 @@ class ProtobufPlugin implements Plugin<Project> {
         }
       }
 
-      // Create a 'compileProto' configuration as a bucket of dependencies that contains resources
-      // attribute for compileClasspath dependencies. This works around 'java-library' plugin
-      // not exposing resources to consumers for compilation.
+      // Create a 'compileProtoPath' configuration as a bucket of dependencies that contains
+      // resources attribute for compileClasspath dependencies. This works around 'java-library'
+      // plugin not exposing resources to consumers for compilation.
       // Some Android sourceSet does not have 'compileClasspath' configuration, not even
       // 'compile' or 'implementation'.
-      String compileProtoConfigName = Utils.getConfigName(sourceSetName, 'compileProto')
+      String compileProtoConfigName = Utils.getConfigName(sourceSetName, 'compileProtoPath')
       String compileClasspathConfigName = Utils.getConfigName(sourceSetName, 'compileClasspath')
       if (project.configurations.findByName(compileClasspathConfigName) &&
               project.configurations.findByName(compileProtoConfigName) == null) {
@@ -385,7 +385,7 @@ class ProtobufPlugin implements Plugin<Project> {
           description = "Extracts proto files from compile dependencies for includes"
           destDir = getExtractedIncludeProtosDir(sourceSetOrVariantName) as File
           inputFiles.from(compileClasspathConfiguration
-            ?: project.configurations[Utils.getConfigName(sourceSetOrVariantName, 'compileProto')])
+            ?: project.configurations[Utils.getConfigName(sourceSetOrVariantName, 'compileProtoPath')])
 
           // TL; DR: Make protos in 'test' sourceSet able to import protos from the 'main'
           // sourceSet.  Sub-configurations, e.g., 'testCompile' that extends 'compile', don't

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -55,6 +55,7 @@ class ProtobufPlugin implements Plugin<Project> {
     // any one of these plugins should be sufficient to proceed with applying this plugin
     private static final List<String> PREREQ_PLUGIN_OPTIONS = [
             'java',
+            'java-library',
             'com.android.application',
             'com.android.feature',
             'com.android.library',

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -175,9 +175,12 @@ class ProtobufPlugin implements Plugin<Project> {
       // Create a 'compileProto' configuration as a bucket of dependencies that contains resources
       // attribute for compileClasspath dependencies. This works around 'java-library' plugin
       // not exposing resources to consumers for compilation.
+      // Some Android sourceSet does not have 'compileClasspath' configuration, not even
+      // 'compile' or 'implementation'.
       String compileProtoConfigName = Utils.getConfigName(sourceSetName, 'compileProto')
       String compileClasspathConfigName = Utils.getConfigName(sourceSetName, 'compileClasspath')
-      if (project.configurations.findByName(compileProtoConfigName) == null) {
+      if (project.configurations.findByName(compileClasspathConfigName) &&
+              project.configurations.findByName(compileProtoConfigName) == null) {
         project.configurations.create(compileProtoConfigName) {
           visible = false
           transitive = true

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -201,7 +201,7 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
-  void "testProjectJavaLibrary should be successfully executed (java-only project as a library) [gradle #gradleVersion]"() {
+  void "testProjectJavaLibrary should be successfully executed (java-only as a library) [gradle #gradleVersion]"() {
     given: "project from testProjectJavaLibrary"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectJavaLibrary')
             .copyDirs('testProjectBase', 'testProjectJavaLibrary')

--- a/testProjectDependentApp/build.gradle
+++ b/testProjectDependentApp/build.gradle
@@ -1,0 +1,31 @@
+// A project that depends on another project and a published artifact, both of
+// which include proto files. The included proto files are added to the
+// --proto_path argument of protoc, so that the protos from this project can
+// import them. However, these imported proto files will not be compiled in
+// this project, since they have already been compiled in their own projects.
+
+apply plugin: 'java'
+apply plugin: 'com.google.protobuf'
+
+repositories {
+    maven { url "https://plugins.gradle.org/m2/" }
+}
+
+dependencies {
+    implementation 'com.google.protobuf:protobuf-java:3.0.0'
+    implementation project(':testProjectJavaLibrary')
+
+    testImplementation 'junit:junit:4.12'
+}
+
+protobuf.protoc {
+  artifact = 'com.google.protobuf:protoc:3.0.0'
+}
+
+test.doLast {
+  // This project has compiled only one proto file, despite that it imports
+  // other proto files from dependencies.
+  def generatedFiles = project.fileTree(protobuf.generatedFilesBaseDir + "/main")
+  File onlyGeneratedFile = generatedFiles.singleFile
+  assert 'Dependent.java' == onlyGeneratedFile.name
+}

--- a/testProjectDependentApp/settings.gradle
+++ b/testProjectDependentApp/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testProjectDependentApp'

--- a/testProjectDependentApp/src/main/proto/dependent.proto
+++ b/testProjectDependentApp/src/main/proto/dependent.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package dependent;
+
+// From testProject/src/main/proto
+import "ws/antonov/protobuf/test/test.proto";
+
+// From protobuf-java artifact
+import "google/protobuf/any.proto";
+
+message WrapperMessage {
+  ws.antonov.protobuf.test.Item item = 1;
+  google.protobuf.Any any = 2;
+}

--- a/testProjectDependentApp/src/test/java/DependentTest.java
+++ b/testProjectDependentApp/src/test/java/DependentTest.java
@@ -1,0 +1,19 @@
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+public class DependentTest {
+
+  @Test public void testProtos() {
+    dependent.Dependent.WrapperMessage message =
+        dependent.Dependent.WrapperMessage.newBuilder()
+            .setItem(ws.antonov.protobuf.test.Test.Item.getDefaultInstance())
+            .setAny(com.google.protobuf.Any.getDefaultInstance())
+            .build();
+    assertSame(ws.antonov.protobuf.test.Test.Item.getDefaultInstance(),
+        message.getItem());
+    Dependent2.TestWrapperMessage testMessage =
+        Dependent2.TestWrapperMessage.newBuilder()
+            .setM(message).build();
+  }
+}

--- a/testProjectDependentApp/src/test/proto/dependent2.proto
+++ b/testProjectDependentApp/src/test/proto/dependent2.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+// From the 'main' sourceSet
+import "dependent.proto";
+
+message TestWrapperMessage {
+  dependent.WrapperMessage m = 1;
+}

--- a/testProjectJavaLibrary/build.gradle
+++ b/testProjectJavaLibrary/build.gradle
@@ -1,0 +1,5 @@
+// This build is not a complete project, but is used to generate a project.
+// See: ProtobufPluginTestHelper.groovy
+apply plugin: 'java-library'
+apply plugin: 'idea'
+apply from: 'build_base.gradle'

--- a/testProjectJavaLibrary/settings.gradle
+++ b/testProjectJavaLibrary/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testProjectJavaLibrary'

--- a/testProjectJavaLibrary/src/main/java/Foo.java
+++ b/testProjectJavaLibrary/src/main/java/Foo.java
@@ -1,0 +1,30 @@
+import com.google.protobuf.MessageLite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Foo {
+  public static List<MessageLite> getDefaultInstances() {
+    ArrayList<MessageLite> list = new ArrayList<MessageLite>();
+    // from src/main/proto/test.proto
+    list.add(ws.antonov.protobuf.test.Test.TestMessage.getDefaultInstance());
+    list.add(ws.antonov.protobuf.test.Test.AnotherMessage.getDefaultInstance());
+    list.add(ws.antonov.protobuf.test.Test.Item.getDefaultInstance());
+    list.add(ws.antonov.protobuf.test.Test.DataMap.getDefaultInstance());
+    // from src/main/proto/sample.proto (java_multiple_files == true, thus no outter class)
+    list.add(com.example.tutorial.Msg.getDefaultInstance());
+    list.add(com.example.tutorial.SecondMsg.getDefaultInstance());
+    // from lib/protos.tar.gz/stuff.proto
+    list.add(Stuff.Blah.getDefaultInstance());
+    // from ext/more.proto
+    list.add(More.MoreMsg.getDefaultInstance());
+    list.add(More.Foo.getDefaultInstance());
+    // from ext/test1.proto
+    list.add(test1.Test1.Test1Msg.getDefaultInstance());
+    // from ext/ext1/test1.proto
+    list.add(ext1.Ext1Test1.Ext1Test1Msg.getDefaultInstance());
+    // from ext/test2.proto
+    list.add(test2.Test2.Test2Msg.getDefaultInstance());
+    return list;
+  }
+}

--- a/testProjectJavaLibrary/src/test/java/FooTest.java
+++ b/testProjectJavaLibrary/src/test/java/FooTest.java
@@ -1,0 +1,25 @@
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FooTest {
+  @org.junit.Test
+  public void testMainProtos() {
+    assertEquals(12, Foo.getDefaultInstances().size());
+  }
+
+  @org.junit.Test
+  public void testTestProtos() {
+    // from src/test/proto/test.proto
+    Test.MsgTest.getDefaultInstance();
+    // from lib/protos-test.tar.gz
+    test.Stuff.BlahTest.getDefaultInstance();
+  }
+
+  @org.junit.Test
+  public void testGrpc() {
+    // from src/grpc/proto/
+    assertTrue(com.google.protobuf.GeneratedMessageV3.class.isAssignableFrom(
+        io.grpc.testing.integration.Messages.SimpleRequest.class));
+    assertTrue(Object.class.isAssignableFrom(io.grpc.testing.integration.TestServiceGrpc.class));
+  }
+}


### PR DESCRIPTION
Configuration hierarchy for `java` and `java-library` plugins are different:
- In [`java` plugin](https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations): `compile`(deprecated) is the root configuration, `implementation` extends it and `compileClasspath` extends `implementation`.
- In [`java-library`](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph): `api` is the root configuration, `implementation` extends it and `compileClasspath` extends `implementation`.

Currently, our plugin [extracts included proto for compilation from dependencies in `compile` configuration](https://github.com/google/protobuf-gradle-plugin/blob/f91db82a7de0adc1e71774ebeeb2fd1377f6eb0a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L369). This is wrong even for `java` plugin. Dependencies added to `implementation` configuration will not be captured by our plugin. If your proto file imports some dependent proto from an `implementation` configuration, you will get an import proto file not found error. Plugin tasks should get dependencies from `compileClasspath` configuration, which inherits all dependencies added to its ancestor configurations. Thus, the plugin is able to capture all dependencies for compilation.

However, extracting included proto from dependencies in `compileClasspath` configuration is not enough if some dependency uses `java-library` plugin. Projects depending on some upstream libraries that use `java-library` plugin will only pull in [classes folder instead of the full JAR for compilation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_classes_usage). So proto files in the upstream libraries will not be extracted and consumer project's compilation will fail if it imports proto files from upstream libraries.

Our solution, as explained in https://github.com/google/protobuf-gradle-plugin/issues/363#issuecomment-562802208 is to create an internal configuration that mirrors `compileClasspath` configuration (which extends `compileOnly` and `implementation`) introduced by `java`/`java-library` plugin and add an attribute to also include `resources` (where the proto files are packaged). We are trying to avoid affecting `java`/`java-library` by modifying `compileClasspath` configuration itself. This new configuration is for our plugin's internal usage and users should not directly add dependencies to it.


Related issues: #363 (most clearly reveals the issue), #242, #338, #258
