### PR TITLE
Filter out plugin's Gradle dependencies in test project's classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,9 @@ configurations {
 task createClasspathManifest {
     def outputDir = file("$buildDir/$name")
 
-    inputs.files sourceSets.main.runtimeClasspath
+    inputs.files sourceSets.main.runtimeClasspath.filter {
+      !it.name.contains("gradle-api") && !it.path.contains("$project.gradle.gradleHomeDir")
+    }
     inputs.files configurations.testProjectRuntime
     outputs.dir outputDir
 


### PR DESCRIPTION
`createClasspathManifest` task puts the plugin's `runtimeClasspath` dependencies into test project's classpath, including local Gradle API (why? still confused as `gradleApi` is configured as `compileOnly` dependency but it does appears in `runtime` configuration). This pollutes the test project's classpath (if you look at build files of generated projects for test, the JAR for `gradle-api` with your build version appears in the classpath). No matter which Gradle version the test is running under, test project's classpath always contains the plugin's build version of Gradle. That is, tests aren't really running under the targeted version.

This change manually filters out dependencies used for plugin's build to be included in the test project's classpath. It may not be the real fix, which needs some deep investigation.


Tests for Gradle versions older than 5.6 would fail after this change, #370 drops tests for obsolete gradle versions.