### PR TITLE
Drop tests for Gradle versions older than 5.6

### DIFF
--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -12,8 +12,8 @@ import spock.lang.Unroll
  */
 class AndroidProjectDetectionTest extends Specification {
   // Current supported version is Android plugin 3.3.0+.
-  private static final List<String> GRADLE_VERSION = ["5.0", "5.1.1", "5.4.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.3.0", "3.4.0", "3.5.0"]
+  private static final List<String> GRADLE_VERSION = ["5.6"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]
 
   static void appendUtilIsAndroidProjectCheckTask(File buildFile, boolean assertResult) {
     buildFile << """

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -11,9 +11,8 @@ import spock.lang.Unroll
  * Unit tests for android related functionality.
  */
 class ProtobufAndroidPluginTest extends Specification {
-  // Current supported version is Android plugin 3.3.0+.
-  private static final List<String> GRADLE_VERSION = ["5.0", "5.1.1", "5.4.1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.3.0", "3.4.0", "3.5.0"]
+  private static final List<String> GRADLE_VERSION = ["5.6"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]
 
   @Unroll
   void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Unroll
  */
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6", "6.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
     given: "a basic project with java and com.google.protobuf"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -11,7 +11,7 @@ import spock.lang.Unroll
  */
 class ProtobufKotlinDslPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.0", "5.1", "5.4", "5.6", "6.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0"]
 
   @Unroll
   void "testProjectKotlinDsl should be successfully executed (java-only project) [gradle #gradleVersion]"() {


### PR DESCRIPTION
Currently the plugin builds with Gradle 5.6. Tests coverage for Gradle versions older than 5.6 should have failed. The test setup is somewhat wrong, #369 is trying to fix the issue.