### PR TITLE
Use automatic plugin classpath injection for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,52 +51,18 @@ configurations {
     testProjectRuntime
 }
 
-/**
- * Write file containing all the things that should be in the test projects' class path. This
- * includes the current SNAPSHOT version of protobuf-gradle-plugin and whatever else may be
- * needed by the test projects such as other plugins or libraries.
- */
-task createClasspathManifest {
-    def outputDir = file("$buildDir/$name")
-
-    inputs.files sourceSets.main.runtimeClasspath
-    inputs.files configurations.testProjectRuntime
-    outputs.dir outputDir
-
-    doLast {
-        outputDir.mkdirs()
-        file("$outputDir/plugin-classpath.txt").text = inputs.files.join("\n")
-    }
-}
-
 dependencies {
-    compileOnly gradleApi()
-    compileOnly localGroovy()
     compileOnly "org.gradle:gradle-kotlin-dsl:1.0.4"
 
     compile 'com.google.guava:guava:27.0.1-jre'
     compile 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
     compile 'commons-lang:commons-lang:2.6'
 
-    testCompile gradleTestKit()
-    testCompile gradleApi()
-    testCompile localGroovy()
     testCompile 'junit:junit:4.12'
     testCompile ('org.spockframework:spock-core:1.0-groovy-2.4') {
       exclude module : 'groovy-all'
     }
     testCompile 'commons-io:commons-io:2.5'
-
-    // This kotlin version needs to be compatible with the 
-    // android plugin being used in the test runtime.
-    testProjectRuntime "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
-
-    // Add android plugin to the test classpath, so that we can jump into class definitions,
-    // read their sources, set break points, etc while debugging android unit tests.
-    // Change the version if necessary to match the specific unit test.
-    testRuntime 'com.android.tools.build:gradle:2.3.0'
-    // Add the classpath file to the test runtime classpath
-    testRuntime files(createClasspathManifest)
 }
 
 test.inputs.files fileTree("$projectDir/testProject")

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -11,7 +11,6 @@ import spock.lang.Unroll
  * Verify android projects are identified correctly
  */
 class AndroidProjectDetectionTest extends Specification {
-  // Current supported version is Android plugin 3.3.0+.
   private static final List<String> GRADLE_VERSION = ["5.6"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]
 
@@ -32,13 +31,13 @@ class AndroidProjectDetectionTest extends Specification {
     given: "a project with android plugin"
     File mainProjectDir = ProtobufPluginTestHelper.projectBuilder("singleModuleAndroidProject")
        .copyDirs('testProjectAndroid', 'testProjectAndroidBare')
+       .withAndroidPlugin(agpVersion)
        .build()
     appendUtilIsAndroidProjectCheckTask(new File(mainProjectDir, "build.gradle"), true)
 
     when: "checkForAndroidPlugin task evaluates Utils.isAndroidProject"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-       agpVersion,
        gradleVersion,
        "checkForAndroidPlugin"
     )
@@ -64,13 +63,13 @@ class AndroidProjectDetectionTest extends Specification {
     File mainProjectDir = ProtobufPluginTestHelper.projectBuilder("rootModuleAndroidProject")
        .copyDirs('testProjectAndroid', 'testProjectAndroidBare')
        .copySubProjects(subProjectStaging)
+       .withAndroidPlugin(agpVersion)
        .build()
     appendUtilIsAndroidProjectCheckTask(new File(mainProjectDir, "build.gradle"), true)
 
     when: "checkForAndroidPlugin task evaluates Utils.isAndroidProject"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-            agpVersion,
        gradleVersion,
        "checkForAndroidPlugin"
     )

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -13,6 +13,7 @@ import spock.lang.Unroll
 class ProtobufAndroidPluginTest extends Specification {
   private static final List<String> GRADLE_VERSION = ["5.6"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]
+  private static final List<String> KOTLIN_VERSION = ["1.3.20"]
 
   @Unroll
   void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
@@ -28,11 +29,11 @@ class ProtobufAndroidPluginTest extends Specification {
         .build()
     File mainProjectDir = ProtobufPluginTestHelper.projectBuilder('testProjectAndroidMain')
         .copySubProjects(testProjectStaging, testProjectLiteStaging, testProjectAndroidStaging)
+        .withAndroidPlugin(agpVersion)
         .build()
     when: "build is invoked"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-       agpVersion,
        gradleVersion,
        "testProjectAndroid:build"
     )
@@ -46,7 +47,7 @@ class ProtobufAndroidPluginTest extends Specification {
   }
 
   @Unroll
-  void "testProjectAndroidKotlin should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
+  void "testProjectAndroidKotlin [android #agpVersion, gradle #gradleVersion, kotlin #kotlinVersion]"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"
     File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
         .copyDirs('testProjectBase', 'testProject')
@@ -59,11 +60,12 @@ class ProtobufAndroidPluginTest extends Specification {
         .build()
     File mainProjectDir = ProtobufPluginTestHelper.projectBuilder('testProjectAndroidMain')
         .copySubProjects(testProjectStaging, testProjectLiteStaging, testProjectAndroidStaging)
+        .withAndroidPlugin(agpVersion)
+        .withKotlin(kotlinVersion)
         .build()
     when: "build is invoked"
     BuildResult result = buildAndroidProject(
        mainProjectDir,
-       agpVersion,
        gradleVersion,
        "testProjectAndroid:build"
     )
@@ -74,5 +76,6 @@ class ProtobufAndroidPluginTest extends Specification {
     where:
     agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
+    kotlinVersion << KOTLIN_VERSION
   }
 }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -15,6 +15,7 @@ import spock.lang.Unroll
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
   private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0"]
+  private static final List<String> KOTLIN_VERSIONS = ["1.3.20", "1.3.30"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
     given: "a basic project with java and com.google.protobuf"
@@ -61,6 +62,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build', '--stacktrace')
+      .withPluginClasspath()
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
@@ -86,6 +88,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments('build', '--stacktrace')
+            .withPluginClasspath()
             .withGradleVersion(gradleVersion)
             .forwardStdOutput(new OutputStreamWriter(System.out))
             .forwardStdError(new OutputStreamWriter(System.err))
@@ -100,16 +103,18 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
-  void "testProjectKotlin should be successfully executed (kotlin-only project) [gradle #gradleVersion]"() {
+  void "testProjectKotlin (kotlin-only project) [gradle #gradleVersion, kotlin #kotlinVersion]"() {
     given: "project from testProjectKotlin overlaid on testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectKotlin')
         .copyDirs('testProjectBase', 'testProjectKotlin')
+        .withKotlin(kotlinVersion)
         .build()
 
     when: "build is invoked"
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build', '--stacktrace')
+      .withPluginClasspath()
       .withDebug(true)
       .withGradleVersion(gradleVersion)
       .build()
@@ -120,19 +125,22 @@ class ProtobufJavaPluginTest extends Specification {
 
     where:
     gradleVersion << GRADLE_VERSIONS
+    kotlinVersion << KOTLIN_VERSIONS
   }
 
   @Unroll
-  void "testProjectJavaAndKotlin should be successfully executed (java+kotlin project) [gradle #gradleVersion]"() {
+  void "testProjectJavaAndKotlin (java+kotlin project) [gradle #gradleVersion, kotlin #kotlinVersion]"() {
     given: "project from testProjecJavaAndKotlin overlaid on testProjectKotlin, testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectJavaAndKotlin')
         .copyDirs('testProjectBase', 'testProject', 'testProjectKotlin', 'testProjectJavaAndKotlin')
+        .withKotlin(kotlinVersion)
         .build()
 
     when: "build is invoked"
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build')
+      .withPluginClasspath()
       .withDebug(true)
       .withGradleVersion(gradleVersion)
       .build()
@@ -143,6 +151,7 @@ class ProtobufJavaPluginTest extends Specification {
 
     where:
     gradleVersion << GRADLE_VERSIONS
+    kotlinVersion << KOTLIN_VERSIONS
   }
 
   @Unroll
@@ -156,6 +165,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build', '--stacktrace')
+      .withPluginClasspath()
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
@@ -187,6 +197,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
       .withProjectDir(mainProjectDir)
       .withArguments('testProjectDependent:build', '--stacktrace')
+      .withPluginClasspath()
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
@@ -211,6 +222,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments('build', '--stacktrace')
+            .withPluginClasspath()
             .withGradleVersion(gradleVersion)
             .forwardStdOutput(new OutputStreamWriter(System.out))
             .forwardStdError(new OutputStreamWriter(System.err))
@@ -243,6 +255,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
             .withProjectDir(mainProjectDir)
             .withArguments('testProjectDependentApp:build', '--stacktrace')
+            .withPluginClasspath()
             .withGradleVersion(gradleVersion)
             .forwardStdOutput(new OutputStreamWriter(System.out))
             .forwardStdError(new OutputStreamWriter(System.err))
@@ -267,6 +280,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build', '--stacktrace')
+      .withPluginClasspath()
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
@@ -291,6 +305,7 @@ class ProtobufJavaPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('idea')
+      .withPluginClasspath()
       .withGradleVersion(gradleVersion)
       .build()
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -24,6 +24,7 @@ class ProtobufKotlinDslPluginTest extends Specification {
     BuildResult result = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments('build', '--stacktrace')
+      .withPluginClasspath()
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))

--- a/testProject/build.gradle
+++ b/testProject/build.gradle
@@ -1,5 +1,8 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
-apply plugin: 'java'
-apply plugin: 'idea'
+plugins {
+  id 'java'
+  id 'idea'
+  id 'com.google.protobuf'
+}
 apply from: 'build_base.gradle'

--- a/testProjectAndroid/build.gradle
+++ b/testProjectAndroid/build.gradle
@@ -1,7 +1,8 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
 
+plugins {
+  id 'com.google.protobuf'
+}
 apply plugin: 'com.android.application'
-apply plugin: 'com.google.protobuf'
-
 apply from: 'build_base.gradle'

--- a/testProjectAndroidKotlin/build.gradle
+++ b/testProjectAndroidKotlin/build.gradle
@@ -1,9 +1,12 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
 
-// it is not necessary for protobuf to be applied last
-apply plugin: 'com.google.protobuf'
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+// It is not necessary for protobuf to be applied last.
+// 'kotlin-android' plugin must be applied after 'com.android.application'.
+plugins {
+  id 'com.android.application'
+  id 'kotlin-android'
+  id 'com.google.protobuf'
+}
 
 apply from: 'build_base.gradle'

--- a/testProjectBase/build_base.gradle
+++ b/testProjectBase/build_base.gradle
@@ -1,8 +1,6 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
 
-apply plugin: 'com.google.protobuf'
-
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/testProjectBuildTimeProto/build.gradle
+++ b/testProjectBuildTimeProto/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
+plugins {
+    id 'java'
+    id 'com.google.protobuf'
+}
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }

--- a/testProjectCustomProtoDir/build.gradle
+++ b/testProjectCustomProtoDir/build.gradle
@@ -1,8 +1,10 @@
 // A Java project that demonstrates the customization of proto source
 // directories through the sourceSet DSL.
 
-apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
+plugins {
+  id 'java'
+  id 'com.google.protobuf'
+}
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }

--- a/testProjectDependent/build.gradle
+++ b/testProjectDependent/build.gradle
@@ -4,8 +4,10 @@
 // import them. However, these imported proto files will not be compiled in
 // this project, since they have already been compiled in their own projects.
 
-apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
+plugins {
+  id 'java'
+  id 'com.google.protobuf'
+}
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }

--- a/testProjectDependentApp/build.gradle
+++ b/testProjectDependentApp/build.gradle
@@ -4,8 +4,10 @@
 // import them. However, these imported proto files will not be compiled in
 // this project, since they have already been compiled in their own projects.
 
-apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
+plugins {
+  id 'java'
+  id 'com.google.protobuf'
+}
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }

--- a/testProjectJavaAndKotlin/build.gradle
+++ b/testProjectJavaAndKotlin/build.gradle
@@ -1,6 +1,8 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
-apply plugin: 'kotlin'
-apply plugin: 'java'
-
+plugins {
+  id 'java'
+  id 'org.jetbrains.kotlin.jvm' version "$kotlinVersion"
+  id 'com.google.protobuf'
+}
 apply from: 'build_base.gradle'

--- a/testProjectJavaLibrary/build.gradle
+++ b/testProjectJavaLibrary/build.gradle
@@ -1,5 +1,7 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
-apply plugin: 'java-library'
-apply plugin: 'idea'
+plugins {
+  id 'java-library'
+  id 'com.google.protobuf'
+}
 apply from: 'build_base.gradle'

--- a/testProjectKotlin/build.gradle
+++ b/testProjectKotlin/build.gradle
@@ -1,4 +1,7 @@
 // This build is not a complete project, but is used to generate a project.
 // See: ProtobufPluginTestHelper.groovy
-apply plugin: 'kotlin'
+plugins {
+  id 'org.jetbrains.kotlin.jvm' version "$kotlinVersion"
+  id 'com.google.protobuf'
+}
 apply from: 'build_base.gradle'

--- a/testProjectKotlinDslBase/build.gradle.kts
+++ b/testProjectKotlinDslBase/build.gradle.kts
@@ -2,25 +2,12 @@ import com.google.protobuf.gradle.*
 import org.gradle.api.internal.HasConvention
 import org.gradle.kotlin.dsl.provider.gradleKotlinDslOf
 
-
-buildscript {
-    dependencies {
-        // We cant add classpath dependencies to the build script via applying an external file.
-        // So we have to parse the classpath manifest locally.
-        File("$projectDir/../../createClasspathManifest/plugin-classpath.txt")
-            .readLines()
-            .forEach { classpathEntry ->
-                classpath(files(classpathEntry))
-            }
-    }
-}
-
 plugins {
     java
     idea
+    id("com.google.protobuf")
 }
 
-apply(plugin = "com.google.protobuf")
 // This extension is not auto generated when we apply the plugin using
 // apply(plugin = "com.google.protobuf")
 val Project.protobuf: ProtobufConvention get() =

--- a/testProjectLite/build.gradle
+++ b/testProjectLite/build.gradle
@@ -1,7 +1,9 @@
 // A Java project that demonstrates using protobuf lite version
 
-apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
+plugins {
+  id 'java'
+  id 'com.google.protobuf'
+}
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }


### PR DESCRIPTION
Follow up the issue mentioned in #369. Currently our tests inject plugin's classpath for test projects manually. This pollutes the test project's classpath and make the tests not really run against the designated gradle version.

This change migrates to use GradleRunner's [automatic classpath injection](https://docs.gradle.org/current/userguide/test_kit.html#sub:test-kit-automatic-classpath-injection) for code under test.

- Removed unnecessary gradle/groovy dependencies from plugin's `build.gradle`, as the [Java Gradle Plugin development plugin](https://docs.gradle.org/current/userguide/java_gradle_plugin.html#java_gradle_plugin) already does so.

- Removed [`createClasspathManifest`](https://github.com/google/protobuf-gradle-plugin/blob/2d295c62b17421108ec0c6bc8c64f47cee001d1f/build.gradle#L59) and the corresponding [bridging code](https://github.com/google/protobuf-gradle-plugin/blob/2d295c62b17421108ec0c6bc8c64f47cee001d1f/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy#L28-L56) in test project setup.

- As mentioned in its [documentation](https://docs.gradle.org/current/userguide/test_kit.html#sub:test-kit-automatic-classpath-injection), automatic classpath inject only works if the plugin under test is applied using the plugins DSL.

- Previously we inject Kotlin dependency by putting it on [`testProjectRuntime`](https://github.com/google/protobuf-gradle-plugin/blob/2d295c62b17421108ec0c6bc8c64f47cee001d1f/build.gradle#L92) and adding to the test project's classpath via classpath manifest. Now we set this in `TestProjectBuilder`.

- Refactored methods for building Android test project.