### PR TITLE
Link only generated Java and Kotlin to compilation task by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ files (``*.proto``) in your project. There are two pieces of its job:
     Android project), so that they can be compiled along with your Java sources.
     - Note if you are generating non-Java/Kotlin source files, they will not be
     included for compilation automatically, you will need to add them to sources
-    for language-specific compilations. See details in [this section](#default-outputs).
+    for language-specific compilations. See details in [Default options section](#default-outputs).
 
 For more information about the Protobuf Compiler, please refer to
 [Google Developers Site](https://developers.google.com/protocol-buffers/docs/reference/java-generated?csw=1).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ files (``*.proto``) in your project. There are two pieces of its job:
  2. It adds the generated Java source files to the input of the corresponding
     Java compilation unit (_sourceSet_ in a Java project; _variant_ in an
     Android project), so that they can be compiled along with your Java sources.
+    - Note if you are generating non-Java/Kotlin source files, they will not be
+    included for compilation automatically, you will need to add them to sources
+    for language-specific compilations. See details in [this section](#default-outputs).
 
 For more information about the Protobuf Compiler, please refer to
 [Google Developers Site](https://developers.google.com/protocol-buffers/docs/reference/java-generated?csw=1).
@@ -330,6 +333,8 @@ protobuf {
 }
 ```
 
+Note the generated Python code will not be included for compilation, you will
+need to add them as sources to Python's compilation tasks manually. 
 See [this section](#change-where-files-are-generated) for details about where the code will be generated.
 
 
@@ -451,24 +456,6 @@ changed by setting the ``outputSubDir`` property in the ``builtins`` or
       // Write the generated files under
       // "$generatedFilesBaseDir/$sourceSet/grpcjava"
       outputSubDir = 'grpcjava'
-    }
-  }
-}
-```
-
-#### For non-Java/Kotlin projects
-
-Java and Kotlin are the first class supported languages, generated code will be 
-automatically added for compilation. For projects in other languages, you need
-to manually add generated code to the sourceSets based on the language plugin's
-configuration. The following example adds generated Scala code (by 
-[ScalaPB](https://scalapb.github.io/)) to the `main` sourceSet with `scala` plugin:
-
-```gradle
-sourceSets {
-  main {
-    scala {
-        srcDirs "${protobuf.generatedFilesBaseDir}/main/scalapb"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -456,6 +456,24 @@ changed by setting the ``outputSubDir`` property in the ``builtins`` or
 }
 ```
 
+#### For non-Java/Kotlin projects
+
+Java and Kotlin are the first class supported languages, generated code will be 
+automatically added for compilation. For projects in other languages, you need
+to manually add generated code to the sourceSets based on the language plugin's
+configuration. The following example adds generated Scala code (by 
+[ScalaPB](https://scalapb.github.io/)) to the `main` sourceSet with `scala` plugin:
+
+```gradle
+sourceSets {
+  main {
+    scala {
+        srcDirs "${protobuf.generatedFilesBaseDir}/main/scalapb"
+    }
+  }
+}
+```
+
 ### Protos in dependencies
 
 If a Java project contains proto files, they will be packaged in the jar files

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -43,7 +43,6 @@ import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.tasks.SourceSet
 

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -64,7 +64,6 @@ class ProtobufPlugin implements Plugin<Project> {
             'android-library',
     ]
 
-    private static final String USER_LANG_PROP = 'protobufGradlePluginAdditionalLanguages'
     private static final List<String> SUPPORTED_LANGUAGES = [
         'java',
         'kotlin',
@@ -114,20 +113,9 @@ class ProtobufPlugin implements Plugin<Project> {
         }
     }
 
-    private static List<String> getLanguages(Project project) {
-      List<String> additionalLanguages = []
-      if (project.hasProperty(USER_LANG_PROP)) {
-        additionalLanguages = (List<String>) project.property(USER_LANG_PROP)
-        project.logger.log(
-            LogLevel.WARN,
-            "protobuf plugin is now using additional unsupported languages: " + additionalLanguages)
-      }
-      return SUPPORTED_LANGUAGES + additionalLanguages
-    }
-
     private static void linkGenerateProtoTasksToTask(Task task, GenerateProtoTask genProtoTask) {
       task.dependsOn(genProtoTask)
-      task.source genProtoTask.getOutputSourceDirectorySet()
+      task.source genProtoTask.getOutputSourceDirectorySet().include("**/*.java", "**/*.kt")
     }
 
     private void doApply() {
@@ -468,7 +456,7 @@ class ProtobufPlugin implements Plugin<Project> {
       } else {
         project.sourceSets.each { SourceSet sourceSet ->
           project.protobuf.generateProtoTasks.ofSourceSet(sourceSet.name).each { GenerateProtoTask genProtoTask ->
-            getLanguages(project).each { String lang ->
+            SUPPORTED_LANGUAGES.each { String lang ->
               linkGenerateProtoTasksToTaskName(sourceSet.getCompileTaskName(lang), genProtoTask)
             }
           }


### PR DESCRIPTION
Related issues: #333, #352 

For non Java or Kotlin projects, when users configure with
```
generateProtoTasks {
    all().each { task ->
        task.builtins {
            remove java
        }
    }
}
```
that disables Java code generation, they might get an `compileJava: no source files` error if any Java plugin is applied (could be indirectly applied such as the [Scala plugin](https://docs.gradle.org/current/userguide/scala_plugin.html)).

This is because we always [link the output of `generateProtoTask` to compilation task](https://github.com/google/protobuf-gradle-plugin/blob/8aca60de8ddce37192541d3e6db5242961b95010/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L130) for [Java and Kotlin](https://github.com/google/protobuf-gradle-plugin/blob/8aca60de8ddce37192541d3e6db5242961b95010/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L470-L474). When `generateProtoTask` does not generate Java/Kotlin code (such as Scala only), the Java/Kotlin compilation task is configured with source that contains no Java/Kotlin code. This causes the error.

Java and Kotlin are the two primary languages supported by this plugin. Generated Java and Kotlin code are automatically added to compilation tasks. Previously, if user sets the [`protobufGradlePluginAdditionalLanguages`](https://github.com/google/protobuf-gradle-plugin/blob/8aca60de8ddce37192541d3e6db5242961b95010/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L119-L125) property, it will try to add generated code to compilation task for that language. But this usage hasn't be documented anywhere and would not work for all languages (depends on language specific plugins). Instead, what most non-Java/Kotlin users are doing is to manually configure the sourceSet with generated code for that language, like [this example](https://github.com/scalapb/gradle-demo/blob/1bc60bcb585d67779300cbfbe984615d476dab50/build.gradle#L73-L76).

With current design, there is no perfect way to automatically add generated code to compilation tasks for all languages without causing `no source files` errors given that some language plugin is an extended plugin of another language plugin, such as Scala's case. This solution seems to be the most suitable one that works for both Java/Kotlin and non-Java/Kotlin users.

Delete the usage of `protobufGradlePluginAdditionalLanguages` property. It's never publicly documented, the approach does not work for all languages, and its existence conflicts with this solution.

Added README description for non-Java/Kotlin projects.

Test for non-Java/Kotlin projects is not added (I mainly use [this demo project](https://github.com/scalapb/gradle-demo) provided by @augi for investigating the issue) as we primarily support Java and Kotlin.