### PR TITLE
Eliminate code path for working with old Gradle versions

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -38,9 +38,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -459,13 +457,7 @@ public class GenerateProtoTask extends DefaultTask {
   SourceDirectorySet getOutputSourceDirectorySet() {
     String srcSetName = "generate-proto-" + name
     SourceDirectorySet srcSet
-    if (Utils.compareGradleVersion(project, "5.0") < 0) {
-      Preconditions.checkNotNull(fileResolver)
-      srcSet = new DefaultSourceDirectorySet(
-          srcSetName, this.fileResolver, new DefaultDirectoryFileTreeFactory())
-    } else {
-      srcSet = project.objects.sourceDirectorySet(srcSetName, srcSetName)
-    }
+    srcSet = project.objects.sourceDirectorySet(srcSetName, srcSetName)
     builtins.each { builtin ->
       srcSet.srcDir new File(getOutputDir(builtin))
     }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -40,9 +40,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.tasks.SourceSet
@@ -205,14 +203,7 @@ class ProtobufPlugin implements Plugin<Project> {
     private void addSourceSetExtensions() {
       getSourceSets().all {  sourceSet ->
         String name = sourceSet.name
-        SourceDirectorySet sds
-        if (Utils.compareGradleVersion(project, "5.0") < 0) {
-          // TODO(zhangkun83): remove dependency on Gradle internal APIs once we drop support for < 5.0
-          sds = new DefaultSourceDirectorySet(
-              name, "${name} Proto source", fileResolver, new DefaultDirectoryFileTreeFactory())
-        } else {
-          sds = project.objects.sourceDirectorySet(name, "${name} Proto source")
-        }
+        SourceDirectorySet sds = project.objects.sourceDirectorySet(name, "${name} Proto source")
         sourceSet.extensions.add('proto', sds)
         sds.srcDir("src/${name}/proto")
         sds.include("**/*.proto")

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -80,9 +80,9 @@ class ProtobufPlugin implements Plugin<Project> {
     }
 
     void apply(final Project project) {
-      if (Utils.compareGradleVersion(project, "3.0") < 0) {
+      if (Utils.compareGradleVersion(project, "5.6") < 0) {
         throw new GradleException(
-          "Gradle version is ${project.gradle.gradleVersion}. Minimum supported version is 3.0")
+          "Gradle version is ${project.gradle.gradleVersion}. Minimum supported version is 5.6")
       }
 
         this.project = project


### PR DESCRIPTION
~WIP: we may be able to eliminate [`FileResolver`](https://github.com/google/protobuf-gradle-plugin/blob/8aca60de8ddce37192541d3e6db5242961b95010/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy#L42).~