### PR TITLE
Fix ToolsLocator to work with Gradle 6.1 Instant Execution

### DIFF
--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Unroll
  */
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.1"]
   private static final List<String> KOTLIN_VERSIONS = ["1.3.20", "1.3.30"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
@@ -124,8 +124,7 @@ class ProtobufJavaPluginTest extends Specification {
     ProtobufPluginTestHelper.verifyProjectDir(projectDir)
 
     where:
-    gradleVersion << GRADLE_VERSIONS
-    kotlinVersion << KOTLIN_VERSIONS
+    [gradleVersion, kotlinVersion] << [GRADLE_VERSIONS, KOTLIN_VERSIONS].combinations()
   }
 
   @Unroll
@@ -150,8 +149,7 @@ class ProtobufJavaPluginTest extends Specification {
     ProtobufPluginTestHelper.verifyProjectDir(projectDir)
 
     where:
-    gradleVersion << GRADLE_VERSIONS
-    kotlinVersion << KOTLIN_VERSIONS
+    [gradleVersion, kotlinVersion] << [GRADLE_VERSIONS, KOTLIN_VERSIONS].combinations()
   }
 
   @Unroll

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -11,7 +11,7 @@ import spock.lang.Unroll
  */
 class ProtobufKotlinDslPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.1"]
 
   @Unroll
   void "testProjectKotlinDsl should be successfully executed (java-only project) [gradle #gradleVersion]"() {


### PR DESCRIPTION
This PR fixes `ToolsLocator` to comply with Gradle's Instant Execution constraints.

See https://gradle.github.io/instant-execution/ for more information about what Instant Execution is.

The PR also enables test coverage for Gradle 6.1 and adds more coverage for using Instant Execution on a Java project.

The Android support isn't fixed for Instant Execution by this PR. I'll consider working on it afterwards. Having support for Java projects would already be awesome.