### PR TITLE
Use String instead of GString for option.

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -112,7 +112,7 @@ public class GenerateProtoTask extends DefaultTask {
     @Nullable
     @Optional
     @Input
-    GString path
+    String path
 
     /**
      * If true, source information (comments, locations) will be included in the descriptor set.


### PR DESCRIPTION
If we use this plugin in kotlin (kts). We can't set string literall.