### PR TITLE
Mandatory upgrade for gradle plugin portal publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
 
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
-        classpath "com.gradle.publish:plugin-publish-plugin:0.9.7"
+        classpath "com.gradle.publish:plugin-publish-plugin:0.11.0"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.12.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
     }


### PR DESCRIPTION
A security vulnerability was reported to us on March 4th, 2020. This problem could allow an authorized person to overwrite plugin artifacts on the Plugin Portal if they had access to the build logs that published the plugin

More info https://blog.gradle.org/plugin-portal-update