### PR TITLE
make Utils.getConfigName a precise replica of DefaultSourceSet.configurationNameOf

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -47,8 +47,10 @@ class Utils {
    * Returns the conventional name of a configuration for a sourceSet
    */
   static String getConfigName(String sourceSetName, String type) {
-    return sourceSetName == SourceSet.MAIN_SOURCE_SET_NAME ?
-        type : (sourceSetName + StringUtils.capitalize(type))
+    // same as DefaultSourceSet.configurationNameOf
+    String baseName = sourceSetName == SourceSet.MAIN_SOURCE_SET_NAME ?
+            '' : GUtil.toCamelCase(sourceSetName)
+    return StringUtils.uncapitalize(baseName + StringUtils.capitalize(type))
   }
 
   /**
@@ -57,7 +59,7 @@ class Utils {
    */
   static String getSourceSetSubstringForTaskNames(String sourceSetName) {
     return sourceSetName == SourceSet.MAIN_SOURCE_SET_NAME ?
-        '' : StringUtils.capitalize(sourceSetName)
+        '' : GUtil.toCamelCase(sourceSetName)
   }
 
   private static final String ANDROID_BASE_PLUGIN_ID = "com.android.base"


### PR DESCRIPTION
The code that creates the `compileProtoPath` configuration for
a source set needs to find the full names of the `compileOnly`
and `implementation` configurations based on the source set name.

It isn't possible to read those names directly from the `SourceSet`
object, because `AndroidSourceSet` is not a `SourceSet`. Therefore,
we use the `Utils.getConfigName` method, which subsequently needs
to replicate the behavior of `DefaultSourceSet.configurationNameOf`.

The reason is that when a source set name is unconventional (e.g.
`native-test`), Gradle creates conventionally named configurations
(e.g. `nativeTestCompileOnly`). We need to do the same transformation
on the source set name, otherwise we won't find the configurations.
