### PR TITLE
support proto3 field presence for codegen

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -525,6 +525,17 @@ public class GenerateProtoTask extends DefaultTask {
       }
     }
 
+    // Check if the protoc flag '--experimental_allow_proto3_optional' is
+    // supported. It is only supported for a few versions (since 3.12.0),
+    // in which case we add the flag.
+    if ([
+        tools.protoc.path,
+        "--experimental_allow_proto3_optional",
+        "--help",
+    ].execute().waitFor() == 0) {
+      baseCmd += "--experimental_allow_proto3_optional"
+    }
+
     List<List<String>> cmds = generateCmds(baseCmd, protoFiles, getCmdLengthLimit())
     for (List<String> cmd : cmds) {
       compileFiles(cmd)


### PR DESCRIPTION
Support proto3 field presence for codegen (grpc/grpc-java#7051) by setting the protoc flag 
`--experimental_allow_proto3_optional` by default.

Tested manually (Need depend on com.google.protobuf:protoc:3.12.0 and com.google.protobuf:protobuf-java:3.12.0, and need a proto file with an optional field to test. For testing grpc proto plugin, need depend on local io.grpc:*:1.31.0-SNAPSHOT built with grpc/grpc-java/pull/7054).