### PR TITLE
Avoid using project.copy when possible, and fix serialization

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/CopyActionFacade.java
+++ b/src/main/groovy/com/google/protobuf/gradle/CopyActionFacade.java
@@ -1,0 +1,70 @@
+/*
+ * Original work copyright (c) 2015, Alex Antonov. All rights reserved.
+ * Modified work copyright (c) 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.protobuf.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.tasks.WorkResult;
+
+import javax.inject.Inject;
+
+/**
+ * Interface exposing the file copying feature. Actual implementations may use the
+ * {@link org.gradle.api.file.FileSystemOperations} if available (Gradle 6.0+) or {@link org.gradle.api.Project#copy} if
+ * the version of Gradle is below 6.0.
+ */
+interface CopyActionFacade {
+    WorkResult copy(Action<? super CopySpec> var1);
+
+    class ProjectBased implements CopyActionFacade {
+        private final Project project;
+
+        public ProjectBased(Project project) {
+            this.project = project;
+        }
+
+        @Override
+        public WorkResult copy(Action<? super CopySpec> action) {
+            return project.copy(action);
+        }
+    }
+
+    abstract class FileSystemOperationsBased implements CopyActionFacade {
+        @Inject
+        public abstract FileSystemOperations getFileSystemOperations();
+
+        @Override
+        public WorkResult copy(Action<? super CopySpec> action) {
+            return getFileSystemOperations().copy(action);
+        }
+    }
+}

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -33,25 +33,29 @@ import com.google.common.base.Preconditions
 import groovy.transform.CompileDynamic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
 
 /**
  * Extracts proto files from a dependency configuration.
  */
 @CompileDynamic
-class ProtobufExtract extends DefaultTask {
+abstract class ProtobufExtract extends DefaultTask {
 
   /**
    * The directory for the extracted files.
    */
   private File destDir
   private Boolean isTest = null
-  private final ConfigurableFileCollection inputFiles = project.files()
+  private final ConfigurableFileCollection inputFiles = objectFactory.fileCollection()
+  private final CopyActionFacade copyActionFacade = instantiateCopyActionFacade()
 
   public void setIsTest(boolean isTest) {
     this.isTest = isTest
@@ -70,6 +74,14 @@ class ProtobufExtract extends DefaultTask {
     return inputFiles
   }
 
+  @Internal
+  CopyActionFacade getCopyActionFacade() {
+    return copyActionFacade
+  }
+
+  @Inject
+  abstract ObjectFactory getObjectFactory()
+
   @TaskAction
   void extract() {
     destDir.mkdir()
@@ -77,46 +89,46 @@ class ProtobufExtract extends DefaultTask {
     inputFiles.each { file ->
       logger.debug "Extracting protos from ${file} to ${destDir}"
       if (file.isDirectory()) {
-        project.copy {
-          includeEmptyDirs(false)
-          from(file.path) {
+        copyActionFacade.copy { spec ->
+          spec.includeEmptyDirs = false
+          spec.from(file.path) {
             include '**/*.proto'
           }
-          into(destDir)
+          spec.into(destDir)
         }
       } else if (file.path.endsWith('.proto')) {
         if (!warningLogged) {
           warningLogged = true
-          project.logger.warn "proto file '${file.path}' directly specified in configuration. " +
+          logger.warn "proto file '${file.path}' directly specified in configuration. " +
               "It's likely you specified files('path/to/foo.proto') or " +
               "fileTree('path/to/directory') in protobuf or compile configuration. " +
               "This makes you vulnerable to " +
               "https://github.com/google/protobuf-gradle-plugin/issues/248. " +
               "Please use files('path/to/directory') instead."
         }
-        project.copy {
-          includeEmptyDirs(false)
-          from(file.path)
-          into(destDir)
+        copyActionFacade.copy { spec ->
+          spec.includeEmptyDirs = false
+          spec.from(file.path)
+          spec.into(destDir)
         }
       } else if (file.path.endsWith('.jar') || file.path.endsWith('.zip')) {
-        project.copy {
-          includeEmptyDirs(false)
-          from(project.zipTree(file.path)) {
+        copyActionFacade.copy { spec ->
+          spec.includeEmptyDirs = false
+          spec.from(project.zipTree(file.path)) {
             include '**/*.proto'
           }
-          into(destDir)
+          spec.into(destDir)
         }
       } else if (file.path.endsWith('.tar')
               || file.path.endsWith('.tar.gz')
               || file.path.endsWith('.tar.bz2')
               || file.path.endsWith('.tgz')) {
-        project.copy {
-          includeEmptyDirs(false)
-          from(project.tarTree(file.path)) {
+        copyActionFacade.copy { spec ->
+          spec.includeEmptyDirs = false
+          spec.from(project.tarTree(file.path)) {
             include '**/*.proto'
           }
-          into(destDir)
+          spec.into(destDir)
         }
       } else {
         logger.debug "Skipping unsupported file type (${file.path}); handles only jar, tar, tar.gz, tar.bz2 & tgz"
@@ -133,5 +145,13 @@ class ProtobufExtract extends DefaultTask {
   @OutputDirectory
   protected File getDestDir() {
     return destDir
+  }
+
+  private CopyActionFacade instantiateCopyActionFacade() {
+    if (Utils.compareGradleVersion(project, "6.0") > 0) {
+      // Use object factory to instantiate as that will inject the necessary service.
+      return objectFactory.newInstance(CopyActionFacade.FileSystemOperationsBased)
+    }
+    return new CopyActionFacade.ProjectBased(project)
   }
 }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Unroll
 @CompileDynamic
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.1"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.5-rc-1"]
   private static final List<String> KOTLIN_VERSIONS = ["1.3.20", "1.3.30"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
@@ -80,7 +80,7 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
-  void "testProject should be successfully executed (instant-execution) [gradle #gradleVersion]"() {
+  void "testProject should be successfully executed (configuration cache) [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
       .copyDirs('testProjectBase', 'testProject')
@@ -91,8 +91,7 @@ class ProtobufJavaPluginTest extends Specification {
       .withProjectDir(projectDir)
       .withArguments(
           'build', '--stacktrace',
-          '-Dorg.gradle.unsafe.instant-execution=true',
-          '-Dorg.gradle.unsafe.instant-execution.fail-on-problems=true'
+          '--configuration-cache=warn'
       )
       .withPluginClasspath()
       .withGradleVersion(gradleVersion)
@@ -113,10 +112,10 @@ class ProtobufJavaPluginTest extends Specification {
     result = runner.build()
 
     then: "it reuses the task graph"
-    result.output.contains("Reusing instant execution cache")
+    result.output.contains("Reusing configuration cache")
 
-    and: "it succeeds"
-    result.task(":build").outcome == TaskOutcome.SUCCESS
+    and: "it is up to date"
+    result.task(":build").outcome == TaskOutcome.UP_TO_DATE
     ProtobufPluginTestHelper.verifyProjectDir(projectDir)
 
     where:


### PR DESCRIPTION
Since Gradle 6.0 there is FileSystemOperations API which is compatible
with configuration caching. This PR introduces CopyActionFacade which
exposes the copy method, but implementation is using the new API whne
possible, and reverts to project.copy when Gradle version is lower than 6.0.

This PR also starts using Gradle 6.0 to build the plugin. It is needed in
order to use FileSystemOperations API.

In GenerateProtoTask, SourceSet is now not serialized as part of the
task state, and a provider capturing what is needed is created instead.

Integration test for the Java plugin is updated to Gradle 6.5-rc-1.