### PR TITLE
Update to Gradle 6.0 and fix codenarc warnings

### DIFF
--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -45,6 +45,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   </ruleset-ref>
   <ruleset-ref path='rulesets/exceptions.xml'/>
   <ruleset-ref path='rulesets/formatting.xml'>
+    <exclude name="ClassEndsWithBlankLine"/>
+    <exclude name="ClassStartsWithBlankLine"/>
     <exclude name="Indentation"/>
   </ruleset-ref>
   <ruleset-ref path='rulesets/generic.xml'/>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip

--- a/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
@@ -28,6 +28,7 @@
  */
 package com.google.protobuf.gradle
 
+import groovy.transform.CompileDynamic
 import org.gradle.api.Named
 
 /**
@@ -36,6 +37,7 @@ import org.gradle.api.Named
  * configured, the plugin should try to run the executable from system search
  * path.
  */
+@CompileDynamic
 class ExecutableLocator implements Named {
 
   private final String name

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -31,6 +31,7 @@ package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
+import groovy.transform.CompileDynamic
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Named
@@ -60,6 +61,7 @@ import javax.annotation.Nullable
  * The task that compiles proto files into Java files.
  */
 // TODO(zhangkun83): add per-plugin output dir reconfiguraiton.
+@CompileDynamic
 @CacheableTask
 public class GenerateProtoTask extends DefaultTask {
   // Windows CreateProcess has command line limit of 32768:

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
@@ -28,6 +28,7 @@
  */
 package com.google.protobuf.gradle
 
+import groovy.transform.CompileDynamic
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.tasks.TaskCollection
@@ -36,6 +37,7 @@ import org.gradle.util.ConfigureUtil
 /**
  * The main configuration block exposed as {@code protobuf} in the build script.
  */
+@CompileDynamic
 public class ProtobufConfigurator {
   private final Project project
   private final GenerateProtoTaskCollection tasks

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConvention.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConvention.groovy
@@ -29,6 +29,7 @@
  */
 package com.google.protobuf.gradle
 
+import groovy.transform.CompileDynamic
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.util.ConfigureUtil
@@ -36,6 +37,7 @@ import org.gradle.util.ConfigureUtil
 /**
  * Adds the protobuf {} block as a property of the project.
  */
+@CompileDynamic
 class ProtobufConvention {
     ProtobufConvention(Project project, FileResolver fileResolver) {
         protobuf = new ProtobufConfigurator(project, fileResolver)

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -30,6 +30,7 @@
 package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
+import groovy.transform.CompileDynamic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Input
@@ -42,6 +43,7 @@ import org.gradle.api.tasks.TaskAction
 /**
  * Extracts proto files from a dependency configuration.
  */
+@CompileDynamic
 class ProtobufExtract extends DefaultTask {
 
   /**

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -30,6 +30,7 @@
 package com.google.protobuf.gradle
 
 import com.google.common.collect.ImmutableList
+import groovy.transform.CompileDynamic
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -50,6 +51,7 @@ import javax.inject.Inject
 /**
  * The main class for the protobuf plugin.
  */
+@CompileDynamic
 class ProtobufPlugin implements Plugin<Project> {
     // any one of these plugins should be sufficient to proceed with applying this plugin
     private static final List<String> PREREQ_PLUGIN_OPTIONS = [

--- a/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
@@ -28,6 +28,7 @@
  */
 package com.google.protobuf.gradle
 
+import groovy.transform.CompileDynamic
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
@@ -39,6 +40,7 @@ import org.gradle.api.tasks.PathSensitivity
 /**
  * Holds locations of all external executables, i.e., protoc and plugins.
  */
+@CompileDynamic
 class ToolsLocator {
 
   private final Project project

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -29,6 +29,7 @@
 package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
+import groovy.transform.CompileDynamic
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -42,6 +43,7 @@ import java.util.regex.Matcher
 /**
  * Utility classes.
  */
+@CompileDynamic
 class Utils {
   /**
    * Returns the conventional name of a configuration for a sourceSet

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -2,6 +2,7 @@ package com.google.protobuf.gradle
 
 import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
 
+import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
@@ -10,6 +11,7 @@ import spock.lang.Unroll
 /**
  * Verify android projects are identified correctly
  */
+@CompileDynamic
 class AndroidProjectDetectionTest extends Specification {
   private static final List<String> GRADLE_VERSION = ["5.6"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -2,6 +2,7 @@ package com.google.protobuf.gradle
 
 import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
 
+import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
@@ -10,6 +11,7 @@ import spock.lang.Unroll
 /**
  * Unit tests for android related functionality.
  */
+@CompileDynamic
 class ProtobufAndroidPluginTest extends Specification {
   private static final List<String> GRADLE_VERSION = ["5.6"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -1,6 +1,7 @@
 package com.google.protobuf.gradle
 
 import com.google.common.collect.ImmutableSet
+import groovy.transform.CompileDynamic
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.BuildResult
@@ -12,6 +13,7 @@ import spock.lang.Unroll
 /**
  * Unit tests for normal java and kotlin functionality.
  */
+@CompileDynamic
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
   private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.1"]

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -1,5 +1,6 @@
 package com.google.protobuf.gradle
 
+import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -9,6 +10,7 @@ import spock.lang.Unroll
 /**
  * Unit tests for kotlin dsl extensions.
  */
+@CompileDynamic
 class ProtobufKotlinDslPluginTest extends Specification {
   // Current supported version is Gradle 5+.
   private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.1"]

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -1,5 +1,6 @@
 package com.google.protobuf.gradle
 
+import groovy.transform.CompileDynamic
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -7,6 +8,7 @@ import org.gradle.testkit.runner.GradleRunner
 /**
  * Utility class.
  */
+@CompileDynamic
 final class ProtobufPluginTestHelper {
   private ProtobufPluginTestHelper() {
     // do not instantiate

--- a/src/test/groovy/com/google/protobuf/gradle/ToolsLocatorSpec.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ToolsLocatorSpec.groovy
@@ -28,11 +28,13 @@
  */
 package com.google.protobuf.gradle
 
+import groovy.transform.CompileDynamic
 import spock.lang.Specification
 
 /**
  * Tests for ToolsLocator
  */
+@CompileDynamic
 class ToolsLocatorSpec extends Specification {
   void 'test: `classifier` and `extension` should both be `null`'() {
     given:


### PR DESCRIPTION
This PR updates Gradle version to 6.0 and also fixes all codenarc warnings.