### PR TITLE
Fix configuration caching for Android projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ android:
     - tools
     - build-tools-27.0.3
     - build-tools-28.0.3
+    - build-tools-29.0.2
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
@@ -137,7 +137,7 @@ public class ProtobufConfigurator {
 
     public TaskCollection<GenerateProtoTask> ofVariant(String variant) {
       return all().matching { GenerateProtoTask task ->
-        task.variant.name == variant
+        task.variantName.get() == variant
       }
     }
 

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList
 import groovy.transform.CompileDynamic
 import org.gradle.api.Action
 import org.gradle.api.GradleException
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -335,6 +336,11 @@ class ProtobufPlugin implements Plugin<Project> {
           SourceDirectorySet protoSrcDirSet = sourceSet.proto
           addIncludeDir(protoSrcDirSet.sourceDirectories)
         }
+        ProtobufConfigurator extension = project.protobuf
+        protocLocator.set(project.providers.provider { extension.tools.protoc })
+        pluginsExecutableLocators.set(project.providers.provider {
+            ((NamedDomainObjectContainer<ExecutableLocator>) extension.tools.plugins).asMap
+        })
       }
     }
 

--- a/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
@@ -29,13 +29,11 @@
 package com.google.protobuf.gradle
 
 import groovy.transform.CompileDynamic
-import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.file.FileCollection
-import org.gradle.api.tasks.PathSensitivity
 
 /**
  * Holds locations of all external executables, i.e., protoc and plugins.
@@ -113,22 +111,7 @@ class ToolsLocator {
 
     for (GenerateProtoTask protoTask in protoTasks) {
       if (protoc.is(locator) || protoTask.hasPlugin(locator.name)) {
-        // register the tool artifact files as a task input
-        protoTask.inputs.files(artifactFiles)
-            .withPathSensitivity(PathSensitivity.NONE)
-            .withPropertyName("config.${locator.name}")
-
-        protoTask.doFirst {
-          if (locator.path == null) {
-            project.logger.info("Resolving artifact: ${notation}")
-            File file = artifactFiles.singleFile
-            if (!file.canExecute() && !file.setExecutable(true)) {
-              throw new GradleException("Cannot set ${file} as executable")
-            }
-            project.logger.info("Resolved artifact: ${file}")
-            locator.path = file.path
-          }
-        }
+        protoTask.locatorToAlternativePathsMapping.put(locator.name, artifactFiles)
       }
     }
   }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -1,9 +1,11 @@
 package com.google.protobuf.gradle
 
 import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
+import static com.google.protobuf.gradle.ProtobufPluginTestHelper.getAndroidGradleRunner
 
 import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -13,8 +15,8 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufAndroidPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5-milestone-1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0-alpha10"]
   private static final List<String> KOTLIN_VERSION = ["1.3.20"]
 
   @Unroll
@@ -49,6 +51,66 @@ class ProtobufAndroidPluginTest extends Specification {
   }
 
   @Unroll
+  void "testProjectAndroid succeeds with configuration cache [android #agpVersion, gradle #gradleVersion]"() {
+    given: "project from testProject, testProjectLite & testProjectAndroid"
+    File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
+            .copyDirs('testProjectBase', 'testProject')
+            .build()
+    File testProjectAndroidStaging = ProtobufPluginTestHelper.projectBuilder('testProjectAndroid')
+            .copyDirs('testProjectAndroidBase', 'testProjectAndroid')
+            .build()
+    File testProjectLiteStaging = ProtobufPluginTestHelper.projectBuilder('testProjectLite')
+            .copyDirs('testProjectLite')
+            .build()
+    File mainProjectDir = ProtobufPluginTestHelper.projectBuilder('testProjectAndroidMain')
+            .copySubProjects(testProjectStaging, testProjectLiteStaging, testProjectAndroidStaging)
+            .withAndroidPlugin(agpVersion)
+            .build()
+    and:
+    GradleRunner runner = getAndroidGradleRunner(
+            mainProjectDir,
+            gradleVersion,
+            "testProjectAndroid:assembleDebug",
+            "-Dorg.gradle.unsafe.instant-execution=true",
+            "-Dorg.gradle.unsafe.instant-execution.fail-on-problems=false"
+    )
+    when: "build is invoked"
+    BuildResult result = runner.build()
+
+    then: "it caches the task graph"
+    result.output.contains("Calculating task graph")
+
+    and: "it succeed"
+    result.task(":testProjectAndroid:assembleDebug").outcome == TaskOutcome.SUCCESS
+
+    when: "build is invoked again"
+    result = runner.build()
+
+    then: "it reuses the task graph"
+    result.output.contains("Reusing instant execution cache")
+
+    and: "it is up to date"
+    result.task(":testProjectAndroid:assembleDebug").outcome == TaskOutcome.UP_TO_DATE
+
+    when: "clean is invoked, before a build"
+    buildAndroidProject(
+            mainProjectDir,
+            gradleVersion,
+            "testProjectAndroid:clean",
+            "-Dorg.gradle.unsafe.instant-execution=true",
+            "-Dorg.gradle.unsafe.instant-execution.fail-on-problems=false"
+    )
+    result = runner.build()
+
+    then: "it succeed"
+    result.task(":testProjectAndroid:assembleDebug").outcome == TaskOutcome.SUCCESS
+
+    where:
+    agpVersion << ANDROID_PLUGIN_VERSION.takeRight(1)
+    gradleVersion << GRADLE_VERSION.takeRight(1)
+  }
+
+  @Unroll
   void "testProjectAndroidKotlin [android #agpVersion, gradle #gradleVersion, kotlin #kotlinVersion]"() {
     given: "project from testProject, testProjectLite & testProjectAndroid"
     File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
@@ -78,6 +140,6 @@ class ProtobufAndroidPluginTest extends Specification {
     where:
     agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
-    kotlinVersion << KOTLIN_VERSION
+    kotlinVersion << KOTLIN_VERSION + KOTLIN_VERSION
   }
 }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -28,18 +28,24 @@ final class ProtobufPluginTestHelper {
   }
 
   static BuildResult buildAndroidProject(
-     File mainProjectDir, String gradleVersion, String fullPathTask) {
+     File mainProjectDir, String gradleVersion, String fullPathTask, String... arguments) {
+    return getAndroidGradleRunner(mainProjectDir, gradleVersion, fullPathTask, arguments).build()
+  }
+
+  static GradleRunner getAndroidGradleRunner(
+     File mainProjectDir, String gradleVersion, String fullPathTask, String... arguments) {
     File localBuildCache = new File(mainProjectDir, ".buildCache")
     if (localBuildCache.exists()) {
       localBuildCache.deleteDir()
     }
+    List<String> args = arguments.toList()
+    // set android build cache to avoid using home directory on travis CI.
+    args.add("-Pandroid.buildCacheDir=$localBuildCache".toString())
+    args.add(fullPathTask)
+    args.add("--stacktrace")
     return GradleRunner.create()
        .withProjectDir(mainProjectDir)
-       .withArguments(
-       // set android build cache to avoid using home directory on travis CI.
-       "-Pandroid.buildCacheDir=$localBuildCache",
-       fullPathTask,
-       "--stacktrace")
+       .withArguments(args)
        .withPluginClasspath()
        .withGradleVersion(gradleVersion)
        .forwardStdOutput(new OutputStreamWriter(System.out))
@@ -47,7 +53,6 @@ final class ProtobufPluginTestHelper {
     // Enabling debug causes the test to fail with Android plugin version 3.3.0+.
     // See https://docs.gradle.org/current/javadoc/org/gradle/testkit/runner/GradleRunner.html#isDebug--
     // .withDebug(true)
-       .build()
   }
 
   /**


### PR DESCRIPTION
Avoid serializing entire task state and  extract necessary information
by using Providers. This avoids accessing the project instance during
execution.

When finding the path for the ExecutableLocator, instead of relying
on Task.doFirst additional task property is added. During execution,
this property is used to compute the final location of the executable.
This is necessary in order to capture ExecutableLocators correctly, as
final value used to be set during execution (which is too late).