### PR TITLE
Declare GenerateProtoTask.descriptorPath as an @OutputFile

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -53,6 +53,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
@@ -129,7 +130,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
      */
     @Nullable
     @Optional
-    @Input
+    @OutputFile
     String path
 
     /**


### PR DESCRIPTION
Given the task actually writes to this file.

Without this fix, when loading the outputs from the build cache the descriptor was missing.

See https://github.com/google/protobuf-gradle-plugin/issues/410