### PR TITLE
Add support for --experimental_allow_proto3_optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,12 +456,12 @@ changed by setting the ``outputSubDir`` property in the ``builtins`` or
 }
 ```
 
-#### Enable experimental field visibility in proto3
+#### Enable experimental field presence in proto3
 
 This requires protoc >= 3.12.
 
 Consult the Protobuf documentation for more information about
-[field visibility](https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md).
+[field presence](https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md).
 
 ```gradle
 { task ->

--- a/README.md
+++ b/README.md
@@ -456,6 +456,21 @@ changed by setting the ``outputSubDir`` property in the ``builtins`` or
 }
 ```
 
+#### Enable experimental field visibility in proto3
+
+This requires protoc >= 3.12.
+
+Consult the Protobuf documentation for more information about
+[field visibility](https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md).
+
+```gradle
+{ task ->
+  // If true, enables --experimental_allow_proto3_optional flag in protoc.
+  // Default is false.
+  task.experimentalAllowProto3Optional = true
+}
+```
+
 ### Protos in dependencies
 
 If a Java project contains proto files, they will be packaged in the jar files

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -153,6 +153,14 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @Internal("Handled as input via getDescriptorSetOptionsForCaching()")
   final DescriptorSetOptions descriptorSetOptions = new DescriptorSetOptions()
 
+  /**
+   * If true, will set the protoc flag --experimental_allow_proto3_optional
+   *
+   * Default: false
+   */
+  @Input
+  boolean experimentalAllowProto3Optional
+
   // protoc allows you to prefix comma-delimited options to the path in
   // the --*_out flags, e.g.,
   // - Without options: --java_out=/path/to/output
@@ -572,6 +580,10 @@ public abstract class GenerateProtoTask extends DefaultTask {
       if (descriptorSetOptions.includeSourceInfo) {
         baseCmd += "--include_source_info"
       }
+    }
+
+    if (experimentalAllowProto3Optional) {
+      baseCmd += "--experimental_allow_proto3_optional"
     }
 
     List<List<String>> cmds = generateCmds(baseCmd, protoFiles, getCmdLengthLimit())

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -338,6 +338,31 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
+  void "testProjectProto3Optional should be successfully executed [gradle #gradleVersion]"() {
+    given: "project from testProjectProto3Optional"
+    File projectDir = ProtobufPluginTestHelper.projectBuilder('testProjectProto3Optional')
+        .copyDirs('testProjectProto3Optional')
+        .build()
+
+    when: "build is invoked"
+    BuildResult result = GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments('build', '--stacktrace')
+      .withPluginClasspath()
+      .withGradleVersion(gradleVersion)
+      .forwardStdOutput(new OutputStreamWriter(System.out))
+      .forwardStdError(new OutputStreamWriter(System.err))
+      .withDebug(true)
+      .build()
+
+    then: "it succeed"
+    result.task(":build").outcome == TaskOutcome.SUCCESS
+
+    where:
+    gradleVersion << GRADLE_VERSIONS
+  }
+
+  @Unroll
   void "testProject proto and generated output directories should be added to intellij [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testIdea')

--- a/testProjectProto3Optional/build.gradle
+++ b/testProjectProto3Optional/build.gradle
@@ -1,0 +1,29 @@
+// A Java project that demonstrates use of proto3 optional
+
+plugins {
+  id 'java'
+  id 'com.google.protobuf'
+}
+
+repositories {
+    maven { url "https://plugins.gradle.org/m2/" }
+}
+
+dependencies {
+    compile 'com.google.protobuf:protobuf-java:3.12.2'
+
+    testCompile 'junit:junit:4.12'
+}
+
+protobuf {
+  protoc {
+    // Note this must be >= 3.12
+    artifact = 'com.google.protobuf:protoc:3.12.2'
+  }
+
+  generateProtoTasks {
+    all().each { task ->
+      task.experimentalAllowProto3Optional = true
+    }
+  }
+}

--- a/testProjectProto3Optional/settings.gradle
+++ b/testProjectProto3Optional/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testProjectProto3Optional'

--- a/testProjectProto3Optional/src/main/proto/proto3optional.proto
+++ b/testProjectProto3Optional/src/main/proto/proto3optional.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message MyMessage {
+  int32 no_visibility = 1;
+
+  // this requires --experimental_allow_proto3_optional
+  optional int32 explicit_visibility = 2;
+}

--- a/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
+++ b/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
@@ -4,6 +4,6 @@ public class Proto3OptionalTest {
   public void testProto3OptionalField() {
     // from src/test/proto/test.proto
     // this method only exists if --experimental_allow_proto3_optional is used
-    Test.MsgTest.getDefaultInstance().hasExplicitVisibility();
+    Test.MsgTest.getDefaultInstance().hasExplicitPresence();
   }
 }

--- a/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
+++ b/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
@@ -1,0 +1,11 @@
+import org.junit.Test;
+import Proto3optional.MyMessage;
+
+public class Proto3OptionalTest {
+
+  @Test
+  public void testProto3OptionalField() {
+    // from src/main/proto/proto3optional.proto
+    MyMessage msg = MyMessage.getDefaultInstance();
+  }
+}

--- a/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
+++ b/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
@@ -1,11 +1,8 @@
-import org.junit.Test;
-import Proto3optional.MyMessage;
-
 public class Proto3OptionalTest {
 
-  @Test
+  @org.junit.Test
   public void testProto3OptionalField() {
-    // from src/main/proto/proto3optional.proto
-    MyMessage msg = MyMessage.getDefaultInstance();
+    // from src/test/proto/test.proto
+    Test.MsgTest msg = Test.MsgTest.getDefaultInstance();
   }
 }

--- a/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
+++ b/testProjectProto3Optional/src/test/java/Proto3OptionalTest.java
@@ -3,6 +3,7 @@ public class Proto3OptionalTest {
   @org.junit.Test
   public void testProto3OptionalField() {
     // from src/test/proto/test.proto
-    Test.MsgTest msg = Test.MsgTest.getDefaultInstance();
+    // this method only exists if --experimental_allow_proto3_optional is used
+    Test.MsgTest.getDefaultInstance().hasExplicitVisibility();
   }
 }

--- a/testProjectProto3Optional/src/test/proto/test.proto
+++ b/testProjectProto3Optional/src/test/proto/test.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
 message MsgTest {
-  int32 no_visibility = 1;
+  int32 no_presence = 1;
 
   // this requires --experimental_allow_proto3_optional
-  optional int32 explicit_visibility = 2;
+  optional int32 explicit_presence = 2;
 }

--- a/testProjectProto3Optional/src/test/proto/test.proto
+++ b/testProjectProto3Optional/src/test/proto/test.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-message MyMessage {
+message MsgTest {
   int32 no_visibility = 1;
 
   // this requires --experimental_allow_proto3_optional


### PR DESCRIPTION
Adds `experimentalAllowProto3Optional` property to the proto generation tasks. If true, then `--experimental_allow_proto3_optional` is added to the `protoc` arguments.

~I tried to add a test based on the custom proto dir test, but none of these tests actually pass on my machine (even on master), so I cannot verify it. 😢~ Tests are passing in Travis.

Fixes #415. 