### PR TITLE
Add support for .jar plugins

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -29,6 +29,8 @@
  */
 package com.google.protobuf.gradle
 
+import static java.nio.charset.StandardCharsets.US_ASCII
+
 import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
 import groovy.transform.CompileDynamic
@@ -77,6 +79,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   // Extra command line length when added an additional argument on Windows.
   // Two quotes and a space.
   static final int CMD_ARGUMENT_EXTRA_LENGTH = 3
+  private static final String JAR_SUFFIX = ".jar"
 
   // include dirs are passed to the '-I' option of protoc.  They contain protos
   // that may be "imported" from the source protos, but will not be compiled.
@@ -153,6 +156,20 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @Internal("Handled as input via getDescriptorSetOptionsForCaching()")
   final DescriptorSetOptions descriptorSetOptions = new DescriptorSetOptions()
 
+  private static boolean createNewScriptFile(File outputFile) throws IOException {
+    if (!outputFile.getParentFile().isDirectory() && !outputFile.getParentFile().mkdirs()) {
+      throw new IOException("unable to make directories for file: " + outputFile.getCanonicalPath())
+    }
+    return true
+  }
+
+  private static void finalizeScriptFile(File outputFile) throws IOException {
+    if (!outputFile.setExecutable(true)) {
+      outputFile.delete()
+      throw new IOException("unable to set file as executable: " + outputFile.getCanonicalPath())
+    }
+  }
+
   // protoc allows you to prefix comma-delimited options to the path in
   // the --*_out flags, e.g.,
   // - Without options: --java_out=/path/to/output
@@ -203,10 +220,15 @@ public abstract class GenerateProtoTask extends DefaultTask {
   }
 
   static int getCmdLengthLimit(String os) {
-    if (os != null && os.toLowerCase(Locale.ROOT).indexOf("win") > -1) {
-      return WINDOWS_CMD_LENGTH_LIMIT
-    }
-    return Integer.MAX_VALUE
+    return isWindows(os) ? WINDOWS_CMD_LENGTH_LIMIT : Integer.MAX_VALUE
+  }
+
+  private static boolean isWindows(String os) {
+    return os != null && os.toLowerCase(Locale.ROOT).indexOf("win") > -1
+  }
+
+  private static boolean isWindows() {
+    return isWindows(System.getProperty("os.name"))
   }
 
   void setOutputBaseDir(String outputBaseDir) {
@@ -637,13 +659,49 @@ public abstract class GenerateProtoTask extends DefaultTask {
 
   protected String computeExecutablePath(ExecutableLocator locator) {
     if (locator.path != null) {
-      return locator.path
+      return locator.path.endsWith(JAR_SUFFIX) ? createJarTrampolineScript(locator.path) : locator.path
     }
     File file = locatorToAlternativePathsMapping.getting(locator.name).get().singleFile
+    if (file.name.endsWith(JAR_SUFFIX)) {
+      return createJarTrampolineScript(file.getAbsolutePath())
+    }
+
     if (!file.canExecute() && !file.setExecutable(true)) {
       throw new GradleException("Cannot set ${file} as executable")
     }
     logger.info("Resolved artifact: ${file}")
     return file.path
+  }
+
+  /**
+   * protoc only supports plugins that are a single self contained executable file. For .jar files create a trampoline
+   * script to execute the jar file. Assume the jar is a "fat jar" or "uber jar" and don't attempt any artifact
+   * resolution.
+   * @param jarAbsolutePath Absolute path to the .jar file.
+   * @return The absolute path to the trampoline executable script.
+   */
+  private String createJarTrampolineScript(String jarAbsolutePath) {
+    assert jarAbsolutePath.endsWith(JAR_SUFFIX)
+    boolean isWindows = isWindows()
+    File scriptExecutableFile = new File("${project.buildDir}/scripts/" +
+            jarAbsolutePath[0..(jarAbsolutePath.length() - JAR_SUFFIX.length())] + "-trampoline." +
+            (isWindows ? "bat" : "sh"))
+    try {
+      if (createNewScriptFile(scriptExecutableFile)) {
+        // Rewrite the trampoline file unconditionally (even if it already exists) in case the dependency or versioning
+        // changes we don't need to detect the delta (and the file content is cheap to re-generate).
+        new FileOutputStream(scriptExecutableFile).withCloseable { execOutputStream ->
+          String trampoline = isWindows ?
+                  "@ECHO OFF\r\njava -jar ${jarAbsolutePath} %*\r\n" :
+                  "#!/bin/sh\nexec java -jar ${jarAbsolutePath} \"\$@\"\n"
+          execOutputStream.write(trampoline.getBytes(US_ASCII))
+        }
+        finalizeScriptFile(scriptExecutableFile)
+      }
+      logger.info("Resolved artifact jar: ${jarAbsolutePath}. Created trampoline file: ${scriptExecutableFile}")
+      return scriptExecutableFile.path
+    } catch (IOException e) {
+      throw new GradleException("Unable to generate trampoline for .jar protoc plugin", e)
+    }
   }
 }


### PR DESCRIPTION
Motivation:
Proto only supports plugins as single file executables, and
protobuf-gradle-plugin follows the same pattern. This makes it difficult
to use a plugin that relies on a runtime (e.g. jvm).

Modifications:
- If the plugin is a jar file, create a trampoline script as the protoc
executable which executes the jar file

Result:
Fixes https://github.com/google/protobuf-gradle-plugin/issues/168