### PR TITLE
Add support for .jar plugins

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -704,7 +704,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
       throw new GradleException(".jar protoc plugin path '${jarAbsolutePath}' has no file name")
     }
     File scriptExecutableFile = new File("${project.buildDir}/scripts/" +
-            jarFileName[0..(jarFileName.length() - JAR_SUFFIX.length() - 1)] + "-trampoline." +
+            jarFileName[0..(jarFileName.length() - JAR_SUFFIX.length() - 1)] + "-${getName()}-trampoline." +
             (isWindows ? "bat" : "sh"))
     try {
       mkdirsForFile(scriptExecutableFile)


### PR DESCRIPTION
Motivation:
Proto only supports plugins as single file executables, and
protobuf-gradle-plugin follows the same pattern. This makes it difficult
to use a plugin that relies on a runtime (e.g. jvm).

Modifications:
- If the plugin is a jar file, create a trampoline script as the protoc
executable which executes the jar file

Result:
Fixes https://github.com/google/protobuf-gradle-plugin/issues/168