### PR TITLE
Create compileProtoPath configuration after source set is finalized

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -126,10 +126,14 @@ class ProtobufPlugin implements Plugin<Project> {
 
         addSourceSetExtensions()
         getSourceSets().all { sourceSet ->
-          createConfigurations(sourceSet.name)
+          createProtobufConfiguration(sourceSet.name)
         }
         project.afterEvaluate {
-          // The Android variants are only available at this point.
+          // All custom source sets, configurations created by other plugins,
+          // and Android variants are only available at this point.
+          getSourceSets().each { sourceSet ->
+            createCompileProtoPathConfiguration(sourceSet.name)
+          }
           addProtoTasks()
           project.protobuf.runTaskConfigClosures()
           // Disallow user configuration outside the config closures, because
@@ -149,10 +153,11 @@ class ProtobufPlugin implements Plugin<Project> {
     }
 
     /**
-     * Creates configurations if necessary for a source set so that the build
-     * author can configure dependencies for it.
+     * Creates a 'protobuf' configuration for the given source set. The build author can
+     * configure dependencies for it. The extract-protos task of each source set will
+     * extract protobuf files from dependencies in this configuration.
      */
-    private void  createConfigurations(String sourceSetName) {
+    private void  createProtobufConfiguration(String sourceSetName) {
       String protobufConfigName = Utils.getConfigName(sourceSetName, 'protobuf')
       if (project.configurations.findByName(protobufConfigName) == null) {
         project.configurations.create(protobufConfigName) {
@@ -161,27 +166,29 @@ class ProtobufPlugin implements Plugin<Project> {
           extendsFrom = []
         }
       }
+    }
 
-      // Create a 'compileProtoPath' configuration that extends compilation configurations
-      // as a bucket of dependencies with resources attribute. This works around 'java-library'
-      // plugin not exposing resources to consumers for compilation.
-      // Some Android sourceSets (more precisely, variants) do not have compilation configurations,
-      // they do not contain compilation dependencies, so they would not depend on any upstream
-      // proto files.
+    /**
+     * Creates an internal 'compileProtoPath' configuration for the given source set that extends
+     * compilation configurations as a bucket of dependencies with resources attribute.
+     * The extract-include-protos task of each source set will extract protobuf files from
+     * dependencies in this configuration.
+     *
+     * <p> This works around 'java-library' plugin not exposing resources to consumers for compilation.
+     */
+    private void createCompileProtoPathConfiguration(String sourceSetName) {
       String compileProtoConfigName = Utils.getConfigName(sourceSetName, 'compileProtoPath')
       Configuration compileConfig =
               project.configurations.findByName(Utils.getConfigName(sourceSetName, 'compileOnly'))
       Configuration implementationConfig =
               project.configurations.findByName(Utils.getConfigName(sourceSetName, 'implementation'))
-      if (compileConfig && implementationConfig &&
-              project.configurations.findByName(compileProtoConfigName) == null) {
+      if (project.configurations.findByName(compileProtoConfigName) == null) {
         project.configurations.create(compileProtoConfigName) {
-          visible = false
-          transitive = true
-          extendsFrom = [compileConfig, implementationConfig]
-          canBeConsumed = false
-        }.getAttributes().attribute(
-                LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+            visible = false
+            transitive = true
+            extendsFrom = [compileConfig, implementationConfig]
+            canBeConsumed = false
+        }.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
                 project.getObjects().named(LibraryElements, LibraryElements.RESOURCES))
       }
     }


### PR DESCRIPTION
In #366, we introduced the `compileProtoPath` configuration, which extends from `compileOnly` and `implementation`, as a bucket for containing dependencies that included protos should be extracted from. However, it was created too early such that the `compileOnly` and `implementation` configurations for a custom source set may have not been created.

https://github.com/google/protobuf-gradle-plugin/blob/7f964837a825af2a3e9c32d61889b66aa98b22a1/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L141-L143
adds a hook to create configurations when a source set is added (note the [`DomainObjectCollection.all { }`](https://docs.gradle.org/current/javadoc/org/gradle/api/DomainObjectCollection.html#all-groovy.lang.Closure-) usage). This works fine (and it should work in the way as is) for the `protobuf` configuration as it is a configuration to be exposed to the build author for adding dependencies to be evaluated at the configuration phase. However, if we also try to create the `compileProtoPath` configuration right after the source set is added, its `compileOnly` and `implementation` configurations (added by the Java plugin) may have not been created, which coincides the observation that the source set does not have `compileOnly` and `implementation` configurations as mentioned in the comment (the Java plugin always add them to every source set).

We should create the `compileProtoPath` configuration only after all the other configurations of the corresponding source set is created. Only at that time, `compileOnly` and `implementation` configurations of that source set may be available.