### PR TITLE
Enhance Android test for importing protos defined in variant-under-test's dependencies

### DIFF
--- a/testProjectAndroidBase/src/androidTest/proto/sample.proto
+++ b/testProjectAndroidBase/src/androidTest/proto/sample.proto
@@ -6,6 +6,8 @@ option java_multiple_files = true;
 
 // From the main sourceSet
 import "helloworld.proto";
+// From tested variant's dependency testProjectLite: src/proto
+import "messages.proto";
 
 message Msg {
     string foo = 1;
@@ -14,5 +16,8 @@ message Msg {
 
 message SecondMsg {
     int32 blah = 1;
+    // Uses message type from helloworld.proto
     helloworld.HelloReply reply = 2;
+    // Uses message type from messages.proto
+    grpc.testing.SimpleContext context = 3;
 }

--- a/testProjectAndroidBase/src/test/proto/unittest.proto
+++ b/testProjectAndroidBase/src/test/proto/unittest.proto
@@ -6,6 +6,8 @@ option java_multiple_files = true;
 
 // From the main sourceSet
 import "helloworld.proto";
+// From main's dependency testProjectLite: src/proto
+import "messages.proto";
 
 message UnitTestMsg {
     string foo = 1;
@@ -14,5 +16,8 @@ message UnitTestMsg {
 
 message UnitTestSecondMsg {
     int32 blah = 1;
+    // Uses message type from helloworld.proto
     helloworld.HelloReply reply = 2;
+    // Uses message type from messages.proto
+    grpc.testing.SimpleContext context = 3;
 }


### PR DESCRIPTION
A nice-to-have enhancement mirroring what's being used in #443.

This makes Android tests covers the case that test variants (e.g., unitTest, androidTest) can import proto messages defined in the tested variant's (aka, the variant that this test variant is testing for) dependencies.