### PR TITLE
Avoid storing variantName property in the task

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -103,7 +103,6 @@ public abstract class GenerateProtoTask extends DefaultTask {
   private String buildType
   private boolean isTestVariant
   private FileResolver fileResolver
-  private final Provider<String> variantName = providerFactory.provider { variant.name }
   private final Provider<Boolean> isAndroidProject = providerFactory.provider { Utils.isAndroidProject(project) }
   private final Provider<Boolean> isTestProvider = providerFactory.provider {
     if (Utils.isAndroidProject(project)) {
@@ -342,11 +341,6 @@ public abstract class GenerateProtoTask extends DefaultTask {
   }
 
   @Internal("Not an actual input to the task, only used to find tasks belonging to a variant")
-  Provider<String> getVariantName() {
-    return variantName
-  }
-
-  @Internal("Not an actual input to the task, only used to find tasks belonging to a variant")
   boolean getIsTestVariant() {
     Preconditions.checkState(isAndroidProject.get(),
         'isTestVariant should not be used in a Java project')
@@ -367,7 +361,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
     Preconditions.checkState(isAndroidProject.get(),
         'buildType should not be used in a Java project')
     Preconditions.checkState(
-        variantName.get() == 'test' || buildType,
+        variant.name == 'test' || buildType,
         'buildType is not set and task is not for local unit test variant')
     return buildType
   }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
@@ -137,7 +137,7 @@ public class ProtobufConfigurator {
 
     public TaskCollection<GenerateProtoTask> ofVariant(String variant) {
       return all().matching { GenerateProtoTask task ->
-        task.variantName.get() == variant
+        task.variant.name == variant
       }
     }
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Unroll
 @CompileDynamic
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.5-rc-1"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.7.1"]
   private static final List<String> KOTLIN_VERSIONS = ["1.3.20", "1.3.30"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
@@ -85,13 +85,16 @@ class ProtobufJavaPluginTest extends Specification {
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
       .copyDirs('testProjectBase', 'testProject')
       .build()
+    // Limit max number of problems to catch regressions
+    new File(projectDir, "gradle.properties").write('org.gradle.unsafe.configuration-cache.max-problems=42')
 
     and:
     GradleRunner runner = GradleRunner.create()
       .withProjectDir(projectDir)
       .withArguments(
           'build', '--stacktrace',
-          '--configuration-cache=warn'
+          '--configuration-cache',
+          '--configuration-cache-problems=warn'
       )
       .withPluginClasspath()
       .withGradleVersion(gradleVersion)


### PR DESCRIPTION
When configuration caching is enabled, all task
properties will be serialized, causing variantName
to be queried even for Java-only projects which throws
runtime exception. This PR completely removes that property
as it is required only during task configuration.

Fixes #419.