### PR TITLE
Avoid running signArchives task on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - GRADLE_OPTS="-Xms128m"
 
 script:
-  - ./gradlew clean assemble test --tests com.google.protobuf.gradle.ProtobufJavaPluginTest --stacktrace
+  - ./gradlew clean assemble -x signArchives test --tests com.google.protobuf.gradle.ProtobufJavaPluginTest --stacktrace
   - ./gradlew test --tests com.google.protobuf.gradle.ProtobufKotlinDslPluginTest --stacktrace
   - ./gradlew test --tests com.google.protobuf.gradle.ProtobufAndroidPluginTest --stacktrace
   - ./gradlew test --tests com.google.protobuf.gradle.AndroidProjectDetectionTest --stacktrace


### PR DESCRIPTION
I saw ALL the previous releases tags have failing status (surprising) because `assemble` triggers `signArchives`.