### PR TITLE
Run testProjectAndroidKotlin with new Gradle daemons separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ script:
   - ./gradlew clean assemble test --tests com.google.protobuf.gradle.ProtobufJavaPluginTest --stacktrace
   - ./gradlew test --tests com.google.protobuf.gradle.ProtobufKotlinDslPluginTest --stacktrace
   - ./gradlew test --tests com.google.protobuf.gradle.ProtobufAndroidPluginTest --stacktrace
+  - ./gradlew -stop
+  - ./gradlew test --tests com.google.protobuf.gradle.ProtobufAndroidPluginKotlinTest --stacktrace
   - ./gradlew test --tests com.google.protobuf.gradle.AndroidProjectDetectionTest --stacktrace
   - ./gradlew codenarcMain || (cat ./build/reports/codenarc/main.txt && false)
   - ./gradlew codenarcTest || (cat ./build/reports/codenarc/test.txt && false)

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
@@ -1,0 +1,53 @@
+package com.google.protobuf.gradle
+
+import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
+
+import groovy.transform.CompileDynamic
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@CompileDynamic
+class ProtobufAndroidPluginKotlinTest extends Specification {
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5-milestone-1"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0-alpha10"]
+  private static final List<String> KOTLIN_VERSION = ["1.3.20"]
+
+  /**
+   * This test may take a significant amount of Gradle daemon Metaspace memory in some
+   * Gradle + AGP versions. Try running it separately
+   */
+  @Unroll
+  void "testProjectAndroidKotlin [android #agpVersion, gradle #gradleVersion, kotlin #kotlinVersion]"() {
+    given: "project from testProject, testProjectLite & testProjectAndroid"
+    File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
+            .copyDirs('testProjectBase', 'testProject')
+            .build()
+    File testProjectAndroidStaging = ProtobufPluginTestHelper.projectBuilder('testProjectAndroid')
+            .copyDirs('testProjectAndroidBase', 'testProjectAndroidKotlin')
+            .build()
+    File testProjectLiteStaging = ProtobufPluginTestHelper.projectBuilder('testProjectLite')
+            .copyDirs('testProjectLite')
+            .build()
+    File mainProjectDir = ProtobufPluginTestHelper.projectBuilder('testProjectAndroidMain')
+            .copySubProjects(testProjectStaging, testProjectLiteStaging, testProjectAndroidStaging)
+            .withAndroidPlugin(agpVersion)
+            .withKotlin(kotlinVersion)
+            .build()
+    when: "build is invoked"
+    BuildResult result = buildAndroidProject(
+            mainProjectDir,
+            gradleVersion,
+            "testProjectAndroid:build"
+    )
+
+    then: "it succeed"
+    result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
+
+    where:
+    agpVersion << ANDROID_PLUGIN_VERSION
+    gradleVersion << GRADLE_VERSION
+    kotlinVersion << KOTLIN_VERSION + KOTLIN_VERSION
+    }
+}

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -17,7 +17,6 @@ import spock.lang.Unroll
 class ProtobufAndroidPluginTest extends Specification {
   private static final List<String> GRADLE_VERSION = ["5.6", "6.5-milestone-1"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0-alpha10"]
-  private static final List<String> KOTLIN_VERSION = ["1.3.20"]
 
   @Unroll
   void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
@@ -139,38 +138,5 @@ class ProtobufAndroidPluginTest extends Specification {
     where:
     agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
-  }
-
-  @Unroll
-  void "testProjectAndroidKotlin [android #agpVersion, gradle #gradleVersion, kotlin #kotlinVersion]"() {
-    given: "project from testProject, testProjectLite & testProjectAndroid"
-    File testProjectStaging = ProtobufPluginTestHelper.projectBuilder('testProject')
-        .copyDirs('testProjectBase', 'testProject')
-        .build()
-    File testProjectAndroidStaging = ProtobufPluginTestHelper.projectBuilder('testProjectAndroid')
-        .copyDirs('testProjectAndroidBase', 'testProjectAndroidKotlin')
-        .build()
-    File testProjectLiteStaging = ProtobufPluginTestHelper.projectBuilder('testProjectLite')
-        .copyDirs('testProjectLite')
-        .build()
-    File mainProjectDir = ProtobufPluginTestHelper.projectBuilder('testProjectAndroidMain')
-        .copySubProjects(testProjectStaging, testProjectLiteStaging, testProjectAndroidStaging)
-        .withAndroidPlugin(agpVersion)
-        .withKotlin(kotlinVersion)
-        .build()
-    when: "build is invoked"
-    BuildResult result = buildAndroidProject(
-       mainProjectDir,
-       gradleVersion,
-       "testProjectAndroid:build"
-    )
-
-    then: "it succeed"
-    result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
-
-    where:
-    agpVersion << ANDROID_PLUGIN_VERSION
-    gradleVersion << GRADLE_VERSION
-    kotlinVersion << KOTLIN_VERSION + KOTLIN_VERSION
   }
 }


### PR DESCRIPTION
Tests are run by GradleRunner, which forks a separate process for the build under test. It is surprising that the Gradle daemon   created in the test process [does not honor any Gradle properties](https://discuss.gradle.org/t/testkit-how-to-turn-off-daemon/17843/6), which means configuring Gradle property `org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m` only affects Gradle daemons for the build itself (aka, the main daemon), but not daemons used for builds under test. Passing any argument/environment variable through GradleRunner doesn't seem to make any difference.

From VisualVM, we can see that the daemon process running the build under test still has MaxMetaspaceSize=256m, which is Gradle's default, even though I have set `org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m`. 

<img width="930" alt="single_run" src="https://user-images.githubusercontent.com/503812/99718305-86fe3b00-2a5f-11eb-9356-bc0dd414b65c.png">

The main daemon that invoking the tests honors the Gradle property:

<img width="796" alt="main_daemon" src="https://user-images.githubusercontent.com/503812/99718723-2a4f5000-2a60-11eb-8220-b0a2f208b1ef.png">


The test `testProjectAndroidKotlin` can take significant amount of Metaspace memory with Gradle 6.5-milestone-1 and AGP 4.1.0-alpha10. By running that test alone, I can see that it may take up to ~175 MB Metaspace:
<img width="1289" alt="sing_run_metaspace" src="https://user-images.githubusercontent.com/503812/99718840-5ff43900-2a60-11eb-87f1-f4c869d223b7.png">

When running together with other test methods in `ProtobufAndroidPluginTest`, where it fails to finish, the memory usage is:
 
<img width="1293" alt="metaspace" src="https://user-images.githubusercontent.com/503812/99721280-cd559900-2a63-11eb-839a-024e014cecc6.png">

which almost hits the default 256MB limit (I guess it fails because JVM is unable to expand Metaspace anymore). Android's [lint tasks](https://github.com/google/protobuf-gradle-plugin/blob/c45dbf4908dcddfcca641ef788ad263f3491f0ea/testProjectAndroidBase/build_base.gradle#L62) causes the last increment of memory usage in the graph. Unfortunately, there isn't really an option to skip lint in Android build.

So the easiest way to alleviate this memory issue is to separate this test and run it separately. 