### PR TITLE
Fully enable configuration cache test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ android:
     - build-tools-27.0.3
     - build-tools-28.0.3
     - build-tools-29.0.2
-    - build-tools-30.0.2
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ android:
     - build-tools-27.0.3
     - build-tools-28.0.3
     - build-tools-29.0.2
+    - build-tools-30.0.2
     - android-26
     - extra-android-support
     - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compileOnly "com.android.tools.build:gradle:3.5.0"
 
     compile 'com.google.guava:guava:27.0.1-jre'
-    compile 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
+    compile 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
     compile 'commons-lang:commons-lang:2.6'
 
     testCompile 'junit:junit:4.12'

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -15,8 +15,8 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufAndroidPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6", "6.5", "6.7"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-alpha06"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5", "6.8"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-beta04"]
 
   @Unroll
   void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
@@ -70,8 +70,7 @@ class ProtobufAndroidPluginTest extends Specification {
             mainProjectDir,
             gradleVersion,
             "testProjectAndroid:assembleDebug",
-            "-Dorg.gradle.unsafe.configuration-cache=true",
-            "-Dorg.gradle.unsafe.configuration-cache-problems=warn"
+            "-Dorg.gradle.unsafe.configuration-cache=true"
     )
     when: "build is invoked"
     BuildResult result = runner.build()
@@ -96,8 +95,7 @@ class ProtobufAndroidPluginTest extends Specification {
             mainProjectDir,
             gradleVersion,
             "testProjectAndroid:clean",
-            "-Dorg.gradle.unsafe.configuration-cache=true",
-            "-Dorg.gradle.unsafe.configuration-cache-problems=warn"
+            "-Dorg.gradle.unsafe.configuration-cache=true"
     )
     result = runner.build()
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Unroll
 @CompileDynamic
 class ProtobufAndroidPluginTest extends Specification {
   private static final List<String> GRADLE_VERSION = ["5.6", "6.5", "6.8"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-beta04"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-alpha10"]
 
   @Unroll
   void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -15,8 +15,8 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufAndroidPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6", "6.5-milestone-1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0-alpha10"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5", "6.7"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-alpha06"]
 
   @Unroll
   void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
@@ -70,8 +70,8 @@ class ProtobufAndroidPluginTest extends Specification {
             mainProjectDir,
             gradleVersion,
             "testProjectAndroid:assembleDebug",
-            "-Dorg.gradle.unsafe.instant-execution=true",
-            "-Dorg.gradle.unsafe.instant-execution.fail-on-problems=false"
+            "-Dorg.gradle.unsafe.configuration-cache=true",
+            "-Dorg.gradle.unsafe.configuration-cache-problems=warn"
     )
     when: "build is invoked"
     BuildResult result = runner.build()
@@ -86,7 +86,7 @@ class ProtobufAndroidPluginTest extends Specification {
     result = runner.build()
 
     then: "it reuses the task graph"
-    result.output.contains("Reusing instant execution cache")
+    result.output.contains("Reusing configuration cache")
 
     and: "it is up to date"
     result.task(":testProjectAndroid:assembleDebug").outcome == TaskOutcome.UP_TO_DATE
@@ -96,8 +96,8 @@ class ProtobufAndroidPluginTest extends Specification {
             mainProjectDir,
             gradleVersion,
             "testProjectAndroid:clean",
-            "-Dorg.gradle.unsafe.instant-execution=true",
-            "-Dorg.gradle.unsafe.instant-execution.fail-on-problems=false"
+            "-Dorg.gradle.unsafe.configuration-cache=true",
+            "-Dorg.gradle.unsafe.configuration-cache-problems=warn"
     )
     result = runner.build()
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -93,8 +93,7 @@ class ProtobufJavaPluginTest extends Specification {
       .withProjectDir(projectDir)
       .withArguments(
           'build', '--stacktrace',
-          '--configuration-cache',
-          '--configuration-cache-problems=warn'
+          '--configuration-cache'
       )
       .withPluginClasspath()
       .withGradleVersion(gradleVersion)


### PR DESCRIPTION
The osdetector plugin version 1.7.0 now should be compliant with configuration cache. So removing flags for ignoring configuration cache problems in tests. Java build is fully compliant. Android build still has one problem, but the problem seems to be on the AGP side.

```
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Plugin 'com.android.internal.application': registration of listener on 'TaskExecutionGraph.addTaskExecutionListener' is unsupported
  See https://docs.gradle.org/6.7/userguide/configuration_cache.html#config_cache:requirements:build_listeners

Caused by: org.gradle.api.InvalidUserCodeException: Listener registration 'TaskExecutionGraph.addTaskExecutionListener' by org.gradle.execution.taskgraph.DefaultTaskExecutionGraph@55581730 is unsupported.
	at org.gradle.configurationcache.initialization.DefaultConfigurationCacheProblemsListener.onBuildScopeListenerRegistration(ConfigurationCacheProblemsListener.kt:88)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.event.DefaultListenerManager$ListenerDetails.dispatch(DefaultListenerManager.java:398)
	at org.gradle.internal.event.DefaultListenerManager$ListenerDetails.dispatch(DefaultListenerManager.java:380)
	at org.gradle.internal.event.AbstractBroadcastDispatch.dispatch(AbstractBroadcastDispatch.java:61)
	at org.gradle.internal.event.DefaultListenerManager$EventBroadcast$ListenerDispatch.dispatch(DefaultListenerManager.java:368)
	at org.gradle.internal.event.DefaultListenerManager$EventBroadcast.dispatch(DefaultListenerManager.java:179)
	at org.gradle.internal.event.DefaultListenerManager$EventBroadcast.dispatch(DefaultListenerManager.java:153)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy22.onBuildScopeListenerRegistration(Unknown Source)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.notifyListenerRegistration(DefaultTaskExecutionGraph.java:265)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.addTaskExecutionListener(DefaultTaskExecutionGraph.java:221)
``` 

So still keep `org.gradle.unsafe.configuration-cache-problems=warn` for Android build test.