### PR TITLE
Support outputting generated code directly into JAR/ZIP archives

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -555,7 +555,13 @@ public abstract class GenerateProtoTask extends DefaultTask {
     List<File> protoFiles = sourceFiles.files.sort()
 
     [builtins, plugins]*.each { plugin ->
-      File outputDir = new File(getOutputDir(plugin))
+      String outputPath = getOutputDir(plugin)
+      File outputDir = new File(outputPath)
+      // protoc is capable of output generated files directly to a JAR file
+      // or ZIP archive if the output location ends with .jar/.zip
+      if (outputPath.endsWith(".jar") || outputPath.endsWith(".zip")) {
+        outputDir = outputDir.getParentFile()
+      }
       outputDir.mkdirs()
     }
 


### PR DESCRIPTION
For #478 


Do not create the `outputSubDir`'s leaf as a directory if its name ends with .jar or .zip. This allows output generated code directly into an archive.

See [Java](https://developers.google.com/protocol-buffers/docs/reference/java-generated#invocation) and [Python](https://developers.google.com/protocol-buffers/docs/reference/python-generated#invocation) compiler invocation.