### PR TITLE
Fix typo for setting descriptor location in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ protobuf {
 
   // Allows to override the default for the descriptor set location
   task.descriptorSetOptions.path =
-    "${projectDir}/build/descriptors/{$task.sourceSet.name}.dsc"
+    "${projectDir}/build/descriptors/${task.sourceSet.name}.dsc"
 
   // If true, the descriptor set will contain line number information
   // and comments. Default is false.


### PR DESCRIPTION
The current demo / sample code creates a descriptor file like this `{test}.desc` when `test` was the name of the source set. So, I'm fixing it to remove / not have the curly braces `{}`. I think this was an unintentional bug in the README - probably a typo - typing `{` by mistake first and then `$`. Could also be speed typing's small issues