### PR TITLE
Make IDEA support work out of the box

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -126,8 +126,8 @@ class Utils {
    * not exist, it will be created before the IDE task is run.
    */
   static void addToIdeSources(Project project, boolean isTest, File f, boolean isGenerated) {
-    IdeaModel model = project.getExtensions().findByType(IdeaModel)
-    if (model != null) {
+    project.plugins.withId("idea") {
+      IdeaModel model = project.getExtensions().findByType(IdeaModel)
       if (isTest) {
         model.module.testSourceDirs += f
       } else {


### PR DESCRIPTION
Instead of requiring users to apply the `idea` plugin, which is normally
not necessary when using IDEA's importer.

Fixes #474