### PR TITLE
Readme: Typo in property name for Python's config

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ task.plugins {
 
 ```gradle
 protobuf {
-  generatedFilesDir = "$projectDir/generated"
+  generatedFilesBaseDir = "$projectDir/generated"
 
   generateProtoTasks {
     all().each { task ->


### PR DESCRIPTION
generatedFilesDir -> generatedFilesBaseDir