### PR TITLE
sourceFiles should ignore empty dirs

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -50,6 +50,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -302,8 +303,9 @@ public abstract class GenerateProtoTask extends DefaultTask {
   }
 
   @SkipWhenEmpty
-  @InputFiles
   @PathSensitive(PathSensitivity.RELATIVE)
+  @IgnoreEmptyDirectories
+  @InputFiles
   FileCollection getSourceFiles() {
     return sourceFiles
   }


### PR DESCRIPTION
The `GenerateProto` task only relies on source files, so it should ignore empty directories. Gradle 6.8 introduced the `IgnoreEmptyDirectories` annotation, which allows declaring that.

In this PR, I add the `IgnoreEmptyDirectories` annotation to `GenerateProto.sourceFiles`.