### PR TITLE
Restrict getOutputSourceDirectorySet() to directories only

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -542,10 +542,16 @@ public abstract class GenerateProtoTask extends DefaultTask {
     SourceDirectorySet srcSet
     srcSet = objectFactory.sourceDirectorySet(srcSetName, srcSetName)
     builtins.each { builtin ->
-      srcSet.srcDir new File(getOutputDir(builtin))
+      File dir = new File(getOutputDir(builtin))
+      if (!dir.name.endsWith(".zip") && !dir.name.endsWith(".jar")) {
+        srcSet.srcDir dir
+      }
     }
     plugins.each { plugin ->
-      srcSet.srcDir new File(getOutputDir(plugin))
+      File dir = new File(getOutputDir(plugin))
+      if (!dir.name.endsWith(".zip") && !dir.name.endsWith(".jar")) {
+        srcSet.srcDir dir
+      }
     }
     return srcSet
   }


### PR DESCRIPTION
This is a replacement for #523. Instead of checking for file types, I should have just excluded zip/jars based on filename.