### PR TITLE
Android - Add tested top-level dirs that contains protos

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -426,7 +426,7 @@ class ProtobufPlugin implements Plugin<Project> {
             // ad-hoc solution that manually includes the source protos of 'main' and its
             // dependencies.
             if (Utils.isTest(sourceSetOrVariantName)) {
-              inputFiles.from getSourceSets()['main'].proto
+              inputFiles.from getSourceSets()['main'].proto.sourceDirectories
               inputFiles.from testedCompileClasspathConfiguration
             }
           } else {


### PR DESCRIPTION
When adding protos from the tested variant in Android projects,
add only top-level dirs to avoid logging the warning.

Fixes #357
Test: ProtobufAndroidPluginTest