### PR TITLE
Get rid of CVEs (CVE-2021-29425, CVE-2020-8908, CVE-2020-15250)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,15 +55,15 @@ configurations {
 dependencies {
     compileOnly "com.android.tools.build:gradle:3.5.0"
 
-    compile 'com.google.guava:guava:27.0.1-jre'
+    compile 'com.google.guava:guava:31.0.1-jre'
     compile 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
     compile 'commons-lang:commons-lang:2.6'
 
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
     testCompile ('org.spockframework:spock-core:1.0-groovy-2.4') {
       exclude module : 'groovy-all'
     }
-    testCompile 'commons-io:commons-io:2.5'
+    testCompile 'commons-io:commons-io:2.11'
 }
 
 test.inputs.files fileTree("$projectDir/testProject")

--- a/examples/exampleKotlinDslProject/build.gradle.kts
+++ b/examples/exampleKotlinDslProject/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     // Adding dependency for configuration from custom sourceSet
     "sampleProtobuf"(files("ext/"))
 
-    testCompile("junit:junit:4.12")
+    testCompile("junit:junit:4.13.2")
     // Extra proto source files for test besides the ones residing under
     // "src/test".
     testProtobuf(files("lib/protos-test.tar.gz"))

--- a/examples/exampleProject/build.gradle
+++ b/examples/exampleProject/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   protobuf files("lib/protos.tar.gz")
   protobuf files("ext/")
 
-  testCompile 'junit:junit:4.12'
+  testCompile 'junit:junit:4.13.2'
   // Extra proto source files for test besides the ones residing under
   // "src/test".
   testProtobuf files("lib/protos-test.tar.gz")

--- a/testProjectAndroidBase/build_base.gradle
+++ b/testProjectAndroidBase/build_base.gradle
@@ -111,7 +111,7 @@ dependencies {
       exclude module: "protobuf-lite"
     }
     protobuf files('lib/protos.jar')
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
 }
 
 def assertJavaCompileHasProtoGeneratedDir(Object variant, Collection<String> codegenPlugins) {

--- a/testProjectAndroidDependentBase/build_base.gradle
+++ b/testProjectAndroidDependentBase/build_base.gradle
@@ -111,7 +111,7 @@ dependencies {
         exclude module: "protobuf-lite"
     }
     protobuf files('lib/protos.jar')
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
 }
 
 def assertJavaCompileHasProtoGeneratedDir(Object variant, Collection<String> codegenPlugins) {

--- a/testProjectAndroidKotlinDsl/build.gradle.kts
+++ b/testProjectAndroidKotlinDsl/build.gradle.kts
@@ -145,7 +145,7 @@ dependencies {
     exclude(module = "protobuf-lite")
   }
   protobuf(files("lib/protos.jar"))
-  testCompile("junit:junit:4.12")
+  testCompile("junit:junit:4.13.2")
 }
 
 afterEvaluate {

--- a/testProjectAndroidLibrary/build.gradle
+++ b/testProjectAndroidLibrary/build.gradle
@@ -87,5 +87,5 @@ dependencies {
         // Otherwise Android compile will complain "Multiple dex files define ..."
         exclude module: "protobuf-lite"
     }
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
 }

--- a/testProjectBase/build_base.gradle
+++ b/testProjectBase/build_base.gradle
@@ -30,7 +30,7 @@ dependencies {
   testProtobuf files("lib/protos-test.tar.gz")
 
   compile protobufDep
-  testCompile 'junit:junit:4.12'
+  testCompile 'junit:junit:4.13.2'
   // KotlinFooTest.kt requires reflection utilities
   testCompile "org.jetbrains.kotlin:kotlin-reflect:1.2.0"
   grpcCompile protobufDep

--- a/testProjectCustomProtoDir/build.gradle
+++ b/testProjectCustomProtoDir/build.gradle
@@ -35,7 +35,7 @@ sourceSets {
 dependencies {
     compile 'com.google.protobuf:protobuf-java:3.0.0'
 
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
 }
 
 protobuf.protoc {

--- a/testProjectDependent/build.gradle
+++ b/testProjectDependent/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile 'com.google.protobuf:protobuf-java:3.0.0'
     compile project(':testProject')
 
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
 }
 
 protobuf.protoc {

--- a/testProjectDependentApp/build.gradle
+++ b/testProjectDependentApp/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-java:3.0.0'
     implementation project(':testProjectJavaLibrary')
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 protobuf.protoc {

--- a/testProjectKotlinDslBase/build.gradle.kts
+++ b/testProjectKotlinDslBase/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     testProtobuf(files("lib/protos-test.tar.gz"))
 
     compile(protobufDep)
-    testCompile("junit:junit:4.12")
+    testCompile("junit:junit:4.13.2")
     // KotlinFooTest.kt requires reflection utilities
     testCompile("org.jetbrains.kotlin:kotlin-reflect:1.2.0")
     grpcCompile(protobufDep)

--- a/testProjectLite/build.gradle
+++ b/testProjectLite/build.gradle
@@ -15,7 +15,7 @@ targetCompatibility = JavaVersion.VERSION_1_7
 dependencies {
     compile 'com.google.protobuf:protobuf-lite:3.0.0'
     protobuf files("ext/")
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13.2'
 }
 
 protobuf {


### PR DESCRIPTION
Fixes https://github.com/google/protobuf-gradle-plugin/issues/545