### PR TITLE
Swap to maven-publish plugin

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: clean assemble -x signArchives --stacktrace
+          arguments: clean assemble --stacktrace
         
   test:
     needs: build

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ buildscript {
 ```
 
 To try out the head version, you can download the source and build it
-with ``./gradlew install -x test`` (we skip tests here because they
+with ``./gradlew publishToMavenLocal -x test`` (we skip tests here because they
 require Android SDK), then:
 
 ```gradle

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,7 @@ Releasing
 3. Publish artifacts:
 - Run `git checkout v$RELEASE_VERSION`.
 - Release on Maven Central:
-  - Run `./gradlew uploadArchives`.
+  - Run `./gradlew publish`.
   - Go to the [OSSRH site](https://oss.sonatype.org), under “Staging Repositories”, close and release the 
   artifact.
 - Release on Gradle Plugin Portal:

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'groovy'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.gradle.plugin-publish'
@@ -87,65 +88,71 @@ task javadocJar(type: Jar, dependsOn:javadoc) {
      from javadoc.destinationDir
 }
 
-artifacts {
-     archives sourcesJar
-     archives groovydocJar
-     archives javadocJar
-}
-
 codenarc {
     toolVersion = "1.4"
+}
+
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
+
+tasks.withType(GenerateModuleMetadata) {
+  enabled = false
+}
+
+publishing {
+  publications {
+    pluginMaven(MavenPublication) {
+      artifact sourcesJar
+      artifact groovydocJar
+      artifact javadocJar
+
+      pom {
+        name = project.name
+        description = "Gradle build plugin to handle Protocol Buffers automated code generation and compilation"
+        url = "https://github.com/google/protobuf-gradle-plugin"
+        licenses {
+          license {
+            name = "BSD 3-Clause"
+            url = "http://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+        developers {
+          developer {
+            id = "zhangkun83"
+            name = "Kun Zhang"
+            email = "zhangkun@google.com"
+          }
+        }
+        scm {
+          connection = "scm:git:git://github.com/google/protobuf-gradle-plugin.git"
+          developerConnection = "scm:git:git@github.com:google/protobuf-gradle-plugin.git"
+          url = "https://github.com/google/protobuf-gradle-plugin"
+        }
+      }
+    }
+  }
+
+  repositories {
+    maven {
+      String releaseUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+      String snapshotUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+      url = version.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
+
+      credentials {
+        if (rootProject.hasProperty("ossrhUsername") && rootProject.hasProperty("ossrhPassword")) {
+          username = rootProject.ossrhUsername
+          password = rootProject.ossrhPassword
+        }
+      }
+    }
+  }
 }
 
 // The Gradle plugin portal doesn't allow signature files.
 if (!gradle.startParameter.taskNames.intersect(['publishPlugins'])) {
   signing {
        required { isReleaseVersion }
-       sign configurations.archives
-  }
-}
-
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        if (rootProject.hasProperty("ossrhUsername") && rootProject.hasProperty("ossrhPassword")) {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
-      }
-      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        if (rootProject.hasProperty("ossrhUsername") && rootProject.hasProperty("ossrhPassword")) {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
-        }
-      }
-      pom.project {
-        name project.name
-        description "Gradle build plugin to handle Protocol Buffers automated code generation and compilation"
-        url "https://github.com/google/protobuf-gradle-plugin"
-        licenses {
-          license {
-            name "BSD 3-Clause"
-            url "http://opensource.org/licenses/BSD-3-Clause"
-          }
-        }
-        developers {
-          developer {
-            id "zhangkun83"
-            name "Kun Zhang"
-            email "zhangkun@google.com"
-          }
-        }
-        scm {
-          connection "scm:git:git://github.com/google/protobuf-gradle-plugin.git"
-          developerConnection "scm:git:git@github.com:google/protobuf-gradle-plugin.git"
-          url "https://github.com/google/protobuf-gradle-plugin"
-        }
-      }
-    }
+       sign publishing.publications.pluginMaven
   }
 }
 


### PR DESCRIPTION
Maven-publish is the newer publishing plugin and has the benefit of not
exposing useless scopes (like test) to consumers. See #545

CC @mvniekerk 

@YifeiZhuang, this is similar (but easier) to [the conversion we did in grpc-java](https://github.com/grpc/grpc-java/commit/1c3432c3fb055e40beeb8aee38e114834ca10da5#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7). I've tested this by comparing the output in Maven Local, but also to the snapshot repository. The only differences is the new plugin creates sha256 and sha512 files in addition to md5 and sha1, and it excludes the test scope dependencies from the pom.

Snapshot (with this change):
https://oss.sonatype.org/content/repositories/snapshots/com/google/protobuf/protobuf-gradle-plugin/0.8.19-SNAPSHOT/

Last release:
https://repo1.maven.org/maven2/com/google/protobuf/protobuf-gradle-plugin/0.8.18/