### PR TITLE
Suggest Gradle Plugin Portal instead of Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ It is available on Maven Central. To add dependency to it:
 ```gradle
 buildscript {
   repositories {
-    mavenCentral()
+    gradlePluginPortal()
   }
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.18'
+    classpath 'gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.18'
   }
 }
 ```


### PR DESCRIPTION
The Gradle Plugin Portal has been hosting the plugin for quite a while.
The use of Maven Central is just historical for now-unsupported Gradle
versions that predated the Portal. This change will mean all users would
use the same repository in the plugin portal. Technically there's been
no need to publish to Maven Central for a while now. We'll still publish
there for a while, to make upgrades easier for users, but maybe in a
year it will make sense to publish to the plugin portal exclusively,
especially if we recommend the plugins DSL.

This change recommends the same repository and artifact name as the
plugin portal: https://plugins.gradle.org/plugin/com.google.protobuf .
gradlePluginPortal() is basically a different spelling of `url
"https://plugins.gradle.org/m2/`.

The plugin portal can function with the classpath being
com.google.protobuf instead of gradle.plugin.com.google.protobuf, but it
involves an extra layer of indirection in the repository. Since
plugins.gradle.org is recommending the gradle.plugin prefix, we'll
suggest the same here. We really need to update the docs here to
recommend the plugins DSL anyway, but that will be a separate change.

CC @mvniekerk