### PR TITLE
Add 7.4.2 gradle version in tests

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -5,6 +5,7 @@ jobs:
   validation:
     name: "Validation"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
       - uses: gradle/gradle-build-action@v2
         with:
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
       - uses: gradle/gradle-build-action@v2
         with:
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
       - uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -28,6 +29,7 @@ jobs:
       matrix:
         tests: [ProtobufJavaPluginTest, ProtobufKotlinDslCopySpecTest, ProtobufKotlinDslPluginTest, ProtobufAndroidPluginTest, ProtobufAndroidPluginKotlinTest, AndroidProjectDetectionTest]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -41,6 +43,7 @@ jobs:
   codenarc:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ configurations {
 }
 
 dependencies {
-  compileOnly "com.android.tools.build:gradle:3.5.0"
+  compileOnly "com.android.tools.build:gradle:4.1.0"
 
   implementation 'com.google.guava:guava:27.0.1-jre'
   implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
@@ -92,8 +92,8 @@ codenarc {
     toolVersion = "1.4"
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 tasks.withType(GenerateModuleMetadata) {
   enabled = false
@@ -170,16 +170,6 @@ pluginBundle {
   }
 }
 
-// Releases must be built on Java 1.8.
-tasks.create("checkJavaVersion").doLast {
-  JavaVersion javaVersion = JavaVersion.current()
-  if (!javaVersion.isJava8()) {
-    throw new GradleException(
-        "The plugin must be published under Java 1.8 but ${javaVersion} is found")
-  }
-}
-[uploadArchives, publishPlugins]*.dependsOn checkJavaVersion
-
 if (System.env.CI == 'true') {
   // Normally html output is more user friendly,
   // but we want a console printable file for CI logs
@@ -195,4 +185,10 @@ tasks.named('compileGroovy') {
 }
 tasks.named('compileKotlin') {
     compileKotlin.classpath += files(compileGroovy.destinationDirectory)
+}
+
+test {
+  testLogging {
+    events = ["standard_out", "standard_error", "started", "passed", "failed", "skipped"]
+  }
 }

--- a/src/main/kotlin/com/google/protobuf/gradle/ProtobufConfiguratorExts.kt
+++ b/src/main/kotlin/com/google/protobuf/gradle/ProtobufConfiguratorExts.kt
@@ -1,6 +1,7 @@
 package com.google.protobuf.gradle
 
-import com.android.build.gradle.api.AndroidSourceSet
+import com.android.build.api.dsl.AndroidSourceSet
+import com.android.build.gradle.api.AndroidSourceSet as DeprecatedAndroidSourceSet
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.file.SourceDirectorySet
@@ -64,9 +65,41 @@ fun SourceSet.proto(action: SourceDirectorySet.() -> Unit) {
 
 /**
  * Applies the supplied action to the "proto" [SourceDirectorySet] extension on
- * a receiver of type [AndroidSourceSet] for Android builds.
+ * a receiver of type [DeprecatedAndroidSourceSet] for Android builds.
  *
  * @since 0.8.15
+ * @usage
+ * ```
+ * android {
+ *     sourceSets {
+ *         create("sample") {
+ *             proto {
+ *                 srcDir("src/sample/protobuf")
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @receiver [DeprecatedAndroidSourceSet] The Android source set for which the "proto"
+ * [SourceDirectorySet] extension will be configured
+ *
+ * @param action A configuration lambda to apply on a receiver of type [SourceDirectorySet]
+ * @return [Unit]
+ */
+fun DeprecatedAndroidSourceSet.proto(action: SourceDirectorySet.() -> Unit) {
+    (this as? ExtensionAware)
+        ?.extensions
+        ?.getByName("proto")
+        ?.let { it as?  SourceDirectorySet }
+        ?.apply(action)
+}
+
+/**
+ * Applies the supplied action to the "proto" [SourceDirectorySet] extension on
+ * a receiver of type [AndroidSourceSet] for Android builds.
+ *
+ * @since 0.8.19
  * @usage
  * ```
  * android {
@@ -90,7 +123,7 @@ fun AndroidSourceSet.proto(action: SourceDirectorySet.() -> Unit) {
     (this as? ExtensionAware)
         ?.extensions
         ?.getByName("proto")
-        ?.let { it as?  SourceDirectorySet }
+        ?.let { it as? SourceDirectorySet }
         ?.apply(action)
 }
 

--- a/src/main/kotlin/com/google/protobuf/gradle/ProtobufConfiguratorExts.kt
+++ b/src/main/kotlin/com/google/protobuf/gradle/ProtobufConfiguratorExts.kt
@@ -99,7 +99,7 @@ fun DeprecatedAndroidSourceSet.proto(action: SourceDirectorySet.() -> Unit) {
  * Applies the supplied action to the "proto" [SourceDirectorySet] extension on
  * a receiver of type [AndroidSourceSet] for Android builds.
  *
- * @since 0.8.19
+ * @since 0.9.0
  * @usage
  * ```
  * android {

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -13,8 +13,8 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class AndroidProjectDetectionTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "7.4.2"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "7.2.1"]
 
   static void appendUtilIsAndroidProjectCheckTask(File buildFile, boolean assertResult) {
     buildFile << """
@@ -39,9 +39,10 @@ class AndroidProjectDetectionTest extends Specification {
 
     when: "checkForAndroidPlugin task evaluates Utils.isAndroidProject"
     BuildResult result = buildAndroidProject(
-       mainProjectDir,
-       gradleVersion,
-       "checkForAndroidPlugin"
+        mainProjectDir,
+        gradleVersion,
+        agpVersion,
+        "checkForAndroidPlugin"
     )
 
     then: "Utils.isAndroidProject evaluation matched assertion in task checkForAndroidPlugin"
@@ -73,6 +74,7 @@ class AndroidProjectDetectionTest extends Specification {
     BuildResult result = buildAndroidProject(
        mainProjectDir,
        gradleVersion,
+       agpVersion,
        "checkForAndroidPlugin"
     )
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
@@ -10,9 +10,9 @@ import spock.lang.Unroll
 
 @CompileDynamic
 class ProtobufAndroidPluginKotlinTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6", "6.5-milestone-1"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0-alpha10"]
-  private static final List<String> KOTLIN_VERSION = ["1.3.20"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5-milestone-1", "7.4.2"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0-alpha10", "7.2.1"]
+  private static final List<String> KOTLIN_VERSION = ["1.3.20", "1.3.20", "1.3.40"]
 
   /**
    * This test may take a significant amount of Gradle daemon Metaspace memory in some
@@ -37,9 +37,10 @@ class ProtobufAndroidPluginKotlinTest extends Specification {
             .build()
     when: "build is invoked"
     BuildResult result = buildAndroidProject(
-            mainProjectDir,
-            gradleVersion,
-            "testProjectAndroid:build"
+        mainProjectDir,
+        gradleVersion,
+        agpVersion,
+        "testProjectAndroid:build"
     )
 
     then: "it succeed"
@@ -48,6 +49,6 @@ class ProtobufAndroidPluginKotlinTest extends Specification {
     where:
     agpVersion << ANDROID_PLUGIN_VERSION
     gradleVersion << GRADLE_VERSION
-    kotlinVersion << KOTLIN_VERSION + KOTLIN_VERSION
+    kotlinVersion << KOTLIN_VERSION
     }
 }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -15,8 +15,8 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufAndroidPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6", "6.5", "6.8"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-alpha10"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5", "6.8", "7.4.2"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-alpha10", "7.2.1"]
 
   @Unroll
   void "testProjectAndroid should be successfully executed [android #agpVersion, gradle #gradleVersion]"() {
@@ -36,9 +36,10 @@ class ProtobufAndroidPluginTest extends Specification {
         .build()
     when: "build is invoked"
     BuildResult result = buildAndroidProject(
-       mainProjectDir,
-       gradleVersion,
-       "testProjectAndroid:build"
+        mainProjectDir,
+        gradleVersion,
+        agpVersion,
+        "testProjectAndroid:build"
     )
 
     then: "it succeed"
@@ -69,6 +70,7 @@ class ProtobufAndroidPluginTest extends Specification {
     GradleRunner runner = getAndroidGradleRunner(
             mainProjectDir,
             gradleVersion,
+            agpVersion,
             "testProjectAndroid:assembleDebug",
             "-Dorg.gradle.unsafe.configuration-cache=true"
     )
@@ -94,6 +96,7 @@ class ProtobufAndroidPluginTest extends Specification {
     buildAndroidProject(
             mainProjectDir,
             gradleVersion,
+            agpVersion,
             "testProjectAndroid:clean",
             "-Dorg.gradle.unsafe.configuration-cache=true"
     )
@@ -127,6 +130,7 @@ class ProtobufAndroidPluginTest extends Specification {
     BuildResult result = buildAndroidProject(
             mainProjectDir,
             gradleVersion,
+            agpVersion,
             "testProjectAndroid:build"
     )
 
@@ -158,6 +162,7 @@ class ProtobufAndroidPluginTest extends Specification {
     BuildResult result = buildAndroidProject(
             mainProjectDir,
             gradleVersion,
+            agpVersion,
             "testProjectAndroid:assembleAndroidTest"
     )
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -16,8 +16,8 @@ import spock.lang.Unroll
 @CompileDynamic
 class ProtobufJavaPluginTest extends Specification {
   // Current supported version is Gradle 5+.
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.7.1"]
-  private static final List<String> KOTLIN_VERSIONS = ["1.3.20", "1.3.30"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.7.1", "7.4.2"]
+  private static final List<String> KOTLIN_VERSIONS = ["1.3.20", "1.3.31", "1.3.40"]
 
   void "testApplying java and com.google.protobuf adds corresponding task to project"() {
     given: "a basic project with java and com.google.protobuf"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslCopySpecTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslCopySpecTest.groovy
@@ -12,7 +12,7 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufKotlinDslCopySpecTest extends Specification {
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.7.1", "7.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.0", "6.7.1", "7.0", "7.4.2"]
 
   @Unroll
   void "testProjectKotlinDslCopySpec should declare explicit copy spec [gradle #gradleVersion]"() {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -14,8 +14,8 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufKotlinDslPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.1.1", "6.5"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.0.0", "4.1.0"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.1.1", "6.5", "7.4.2"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.0.0", "4.1.0", "7.2.1"]
 
   @Unroll
   void "testProjectKotlinDsl should be successfully executed (java-only project) [gradle #gradleVersion]"() {
@@ -61,9 +61,10 @@ class ProtobufKotlinDslPluginTest extends Specification {
 
     when: "build is invoked"
     BuildResult result = buildAndroidProject(
-            mainProjectDir,
-            gradleVersion,
-            "testProjectAndroidKotlinDsl:build"
+        mainProjectDir,
+        gradleVersion,
+        agpVersion,
+        "testProjectAndroidKotlinDsl:build"
     )
 
     then: "it succeed"

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -28,19 +28,35 @@ final class ProtobufPluginTestHelper {
   }
 
   static BuildResult buildAndroidProject(
-     File mainProjectDir, String gradleVersion, String fullPathTask, String... arguments) {
-    return getAndroidGradleRunner(mainProjectDir, gradleVersion, fullPathTask, arguments).build()
+      File mainProjectDir,
+      String gradleVersion,
+      String agpVersion,
+      String fullPathTask,
+      String... arguments
+  ) {
+    return getAndroidGradleRunner(mainProjectDir, gradleVersion, agpVersion, fullPathTask, arguments).build()
   }
 
   static GradleRunner getAndroidGradleRunner(
-     File mainProjectDir, String gradleVersion, String fullPathTask, String... arguments) {
+      File mainProjectDir,
+      String gradleVersion,
+      String agpVersion,
+      String fullPathTask,
+      String... arguments
+  ) {
     File localBuildCache = new File(mainProjectDir, ".buildCache")
     if (localBuildCache.exists()) {
       localBuildCache.deleteDir()
     }
     List<String> args = arguments.toList()
     // set android build cache to avoid using home directory on CI.
-    args.add("-Pandroid.buildCacheDir=$localBuildCache".toString())
+    // More details about that if can be found here:
+    // https://developer.android.com/studio/releases/gradle-plugin.html#build-cache-removed
+    args.add("-Dorg.gradle.caching=false")
+    if (agpVersion.take(1).toInteger() <= 4) { // TODO: improve version comparison
+      args.add("-Pandroid.buildCacheDir=$localBuildCache".toString())
+    }
+
     args.add(fullPathTask)
     args.add("--stacktrace")
     return GradleRunner.create()

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -59,6 +59,12 @@ final class ProtobufPluginTestHelper {
 
     args.add(fullPathTask)
     args.add("--stacktrace")
+    // DSL element 'dexOptions' is obsolete and should be removed.
+    // It will be removed in version 8.0 of the Android Gradle plugin.
+    // Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically.
+    //
+    // Set memory limit for all gradle build, not only for dexing
+    args.add("-Dorg.gradle.jvmargs=-Xmx1g")
     return GradleRunner.create()
        .withProjectDir(mainProjectDir)
        .withArguments(args)

--- a/testProjectAndroidBare/build_base.gradle
+++ b/testProjectAndroidBare/build_base.gradle
@@ -11,7 +11,7 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
   }
 }

--- a/testProjectAndroidBase/build_base.gradle
+++ b/testProjectAndroidBase/build_base.gradle
@@ -47,8 +47,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     packagingOptions {

--- a/testProjectAndroidDependentBase/build_base.gradle
+++ b/testProjectAndroidDependentBase/build_base.gradle
@@ -47,8 +47,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     packagingOptions {

--- a/testProjectAndroidKotlin/build.gradle
+++ b/testProjectAndroidKotlin/build.gradle
@@ -10,3 +10,7 @@ plugins {
 }
 
 apply from: 'build_base.gradle'
+
+dependencies {
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+}

--- a/testProjectAndroidKotlinDsl/build.gradle.kts
+++ b/testProjectAndroidKotlinDsl/build.gradle.kts
@@ -77,8 +77,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
   }
 
   packagingOptions {

--- a/testProjectAndroidLibrary/build.gradle
+++ b/testProjectAndroidLibrary/build.gradle
@@ -36,8 +36,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     // https://github.com/square/okio/issues/58

--- a/testProjectBase/build_base.gradle
+++ b/testProjectBase/build_base.gradle
@@ -5,8 +5,8 @@ repositories {
     maven { url "https://plugins.gradle.org/m2/" }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 sourceSets {
   grpc {
@@ -25,12 +25,14 @@ dependencies {
   testProtobuf files("lib/protos-test.tar.gz")
 
   implementation protobufDep
+  implementation 'javax.annotation:javax.annotation-api:1.3.2'
   testImplementation 'junit:junit:4.12'
   // KotlinFooTest.kt requires reflection utilities
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.2.0"
   grpcImplementation protobufDep
   grpcImplementation 'io.grpc:grpc-stub:1.0.0-pre2'
   grpcImplementation 'io.grpc:grpc-protobuf:1.0.0-pre2'
+  grpcImplementation 'javax.annotation:javax.annotation-api:1.3.2'
 }
 
 protobuf {
@@ -60,6 +62,9 @@ jar {
     from sourceSet.output
     dependsOn sourceSet.getCompileTaskName('java')
   }
+
+  // gradle 7+ requires a duplicate strategy to be explicitly defined
+  duplicatesStrategy(DuplicatesStrategy.INCLUDE)
 }
 
 def assertJavaCompileHasProtoGeneratedDir(String sourceSet, Collection<String> codegenPlugins) {

--- a/testProjectJavaAndKotlin/build.gradle
+++ b/testProjectJavaAndKotlin/build.gradle
@@ -6,3 +6,7 @@ plugins {
   id 'com.google.protobuf'
 }
 apply from: 'build_base.gradle'
+
+dependencies {
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+}

--- a/testProjectKotlin/build.gradle
+++ b/testProjectKotlin/build.gradle
@@ -5,3 +5,7 @@ plugins {
   id 'com.google.protobuf'
 }
 apply from: 'build_base.gradle'
+
+dependencies {
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+}

--- a/testProjectKotlinDslBase/build.gradle.kts
+++ b/testProjectKotlinDslBase/build.gradle.kts
@@ -18,8 +18,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 sourceSets {
@@ -41,12 +41,14 @@ dependencies {
     testProtobuf(files("lib/protos-test.tar.gz"))
 
     implementation(protobufDep)
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
     testImplementation("junit:junit:4.12")
     // KotlinFooTest.kt requires reflection utilities
     testImplementation("org.jetbrains.kotlin:kotlin-reflect:1.2.0")
     grpcImplementation(protobufDep)
     grpcImplementation("io.grpc:grpc-stub:1.0.0-pre2")
     grpcImplementation("io.grpc:grpc-protobuf:1.0.0-pre2")
+    grpcImplementation("javax.annotation:javax.annotation-api:1.3.2")
 }
 
 protobuf {
@@ -79,6 +81,9 @@ tasks {
             val compileTaskName = sourceSet.getCompileTaskName("java")
             dependsOn(project.tasks.getByName(compileTaskName))
         }
+
+        // gradle 7+ requires a duplicate strategy to be explicitly defined
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
     }
 
     "test"{

--- a/testProjectLite/build.gradle
+++ b/testProjectLite/build.gradle
@@ -9,8 +9,8 @@ repositories {
     maven { url "https://plugins.gradle.org/m2/" }
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     implementation 'com.google.protobuf:protobuf-lite:3.0.0'


### PR DESCRIPTION
**Background:**
To add support for version catalogs, build caches, incremental build and other new gradle features - project need a newer version of the gradle.

**Changes:**
Run tests also with 7.4.2 gradle version and 7.2.1 agp version. To be sure that project works as expected on the 7.4.2 gradle version of gradle

**Test plan:**
Green pipelines, production code was not changed.