### PR TITLE
Support descriptor_set_in

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -88,6 +88,8 @@ public abstract class GenerateProtoTask extends DefaultTask {
   private final ConfigurableFileCollection includeDirs = objectFactory.fileCollection()
   // source files are proto files that will be compiled by protoc
   private final ConfigurableFileCollection sourceFiles = objectFactory.fileCollection()
+  // descriptor files are proto files that will be passed to protoc as --descriptor_set_in
+  private final ConfigurableFileCollection descriptorSetFiles = objectFactory.fileCollection()
   private final NamedDomainObjectContainer<PluginOptions> builtins = objectFactory.domainObjectContainer(PluginOptions)
   private final NamedDomainObjectContainer<PluginOptions> plugins = objectFactory.domainObjectContainer(PluginOptions)
   private final ProjectLayout projectLayout = project.layout
@@ -310,6 +312,14 @@ public abstract class GenerateProtoTask extends DefaultTask {
     return sourceFiles
   }
 
+  @SkipWhenEmpty
+  @PathSensitive(PathSensitivity.RELATIVE)
+  @IgnoreEmptyDirectories
+  @InputFiles
+  FileCollection getDescriptorSetFiles() {
+    return descriptorSetFiles
+  }
+
   @InputFiles
   @PathSensitive(PathSensitivity.RELATIVE)
   FileCollection getIncludeDirs() {
@@ -514,6 +524,14 @@ public abstract class GenerateProtoTask extends DefaultTask {
   }
 
   /**
+   * Add a collection of proto source files to be compiled.
+   */
+  public void addDescriptorSetFiles(FileCollection files) {
+    checkCanConfig()
+    descriptorSetFiles.from(files)
+  }
+
+  /**
    * Returns true if the Java source set or Android variant is test related.
    */
   @Input
@@ -675,6 +693,23 @@ public abstract class GenerateProtoTask extends DefaultTask {
       if (descriptorSetOptions.includeSourceInfo) {
         baseCmd += "--include_source_info"
       }
+    }
+
+    if(!descriptorSetFiles.isEmpty()){
+      StringBuilder descriptorSetInBuilder = new StringBuilder("--descriptor_set_in=")
+      descriptorSetFiles.eachWithIndex { descriptorSet, index ->
+        if(!descriptorSet.exists()){
+          throw new GradleException("DescriptorSet at ${descriptorSet.absolutePath} does not exist")
+        }
+
+        if(index != 0){
+          descriptorSetInBuilder.append(":")
+        }
+
+        descriptorSetInBuilder.append(descriptorSet.absolutePath)
+      }
+
+      baseCmd += descriptorSetInBuilder
     }
 
     List<List<String>> cmds = generateCmds(baseCmd, protoFiles, getCmdLengthLimit())


### PR DESCRIPTION
Support specifying `descriptor_set_in` files for a `GenerateProtoTask`

Usage (in gradle.kts)

```kotlin
protobuf {
  protoc { .. }

  generateProtoTasks {
    ofSourceSet("main").forEach {
      it.addDescriptorSetFiles(project.layout.projectDirectory.files("sample/file-descriptor-set.desc"))

      (...)
    }
  }
}
```

It's a very naive implementation, but it does the job for me

I also considered other options
- Read all .desc files from proto sourceset
- Create a new sourceSet for descriptor sets

Let me know if you think any of these options is better for the project. 

I'm not an expert at all on protobuf and you might find this PR not appropriate for the project, considering https://github.com/protocolbuffers/protobuf/issues/3973

Related: https://github.com/google/protobuf-gradle-plugin/issues/251

# Use Case

I want to generate code from the descriptor set by passing the proto file names contained in the binary file. This requires some extra tweaks on the plugin that I don't think are worth sharing upstream, but this is the protoc command I'm interested in obtaining

> protoc -ISomePaths --java_out=... --descriptor_set_in=/path/demo-descriptor-set.desc demo.proto

because `demo.proto` does not exist in `SomePaths`, `protoc` falls back to looking for `demo.proto` in the `descriptor_set_in` and generates `class Demo extends GeneratedMessageV3`
