### PR TITLE
Migrate compile configuration to implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,17 +54,17 @@ configurations {
 }
 
 dependencies {
-    compileOnly "com.android.tools.build:gradle:3.5.0"
+  compileOnly "com.android.tools.build:gradle:3.5.0"
 
-    compile 'com.google.guava:guava:27.0.1-jre'
-    compile 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
-    compile 'commons-lang:commons-lang:2.6'
+  implementation 'com.google.guava:guava:27.0.1-jre'
+  implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
+  implementation 'commons-lang:commons-lang:2.6'
 
-    testCompile 'junit:junit:4.12'
-    testCompile ('org.spockframework:spock-core:1.0-groovy-2.4') {
-      exclude module : 'groovy-all'
-    }
-    testCompile 'commons-io:commons-io:2.5'
+  testImplementation 'junit:junit:4.12'
+  testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') {
+    exclude module: 'groovy-all'
+  }
+  testImplementation 'commons-io:commons-io:2.5'
 }
 
 test.inputs.files fileTree("$projectDir/testProject")

--- a/examples/exampleKotlinDslProject/build.gradle.kts
+++ b/examples/exampleKotlinDslProject/build.gradle.kts
@@ -23,13 +23,13 @@ sourceSets{
 }
 
 dependencies {
-    compile("com.google.protobuf:protobuf-java:3.6.1")
-    compile("io.grpc:grpc-stub:1.15.1")
-    compile("io.grpc:grpc-protobuf:1.15.1")
+    implementation("com.google.protobuf:protobuf-java:3.6.1")
+    implementation("io.grpc:grpc-stub:1.15.1")
+    implementation("io.grpc:grpc-protobuf:1.15.1")
     if (JavaVersion.current().isJava9Compatible) {
         // Workaround for @javax.annotation.Generated
         // see: https://github.com/grpc/grpc-java/issues/3633
-        compile("javax.annotation:javax.annotation-api:1.3.1")
+        implementation("javax.annotation:javax.annotation-api:1.3.1")
     }
     // Extra proto source files besides the ones residing under
     // "src/main".
@@ -39,7 +39,7 @@ dependencies {
     // Adding dependency for configuration from custom sourceSet
     "sampleProtobuf"(files("ext/"))
 
-    testCompile("junit:junit:4.12")
+    testImplementation("junit:junit:4.12")
     // Extra proto source files for test besides the ones residing under
     // "src/test".
     testProtobuf(files("lib/protos-test.tar.gz"))

--- a/examples/exampleProject/build.gradle
+++ b/examples/exampleProject/build.gradle
@@ -20,20 +20,20 @@ buildscript {
 }
 
 dependencies {
-  compile 'com.google.protobuf:protobuf-java:3.0.0'
-  compile 'io.grpc:grpc-stub:1.0.0-pre2'
-  compile 'io.grpc:grpc-protobuf:1.0.0-pre2'
+  implementation 'com.google.protobuf:protobuf-java:3.0.0'
+  implementation 'io.grpc:grpc-stub:1.0.0-pre2'
+  implementation 'io.grpc:grpc-protobuf:1.0.0-pre2'
   if (JavaVersion.current().isJava9Compatible()) {
     // Workaround for @javax.annotation.Generated
     // see: https://github.com/grpc/grpc-java/issues/3633
-    compile 'javax.annotation:javax.annotation-api:1.3.1'
+    implementation 'javax.annotation:javax.annotation-api:1.3.1'
   }
   // Extra proto source files besides the ones residing under
   // "src/main".
   protobuf files("lib/protos.tar.gz")
   protobuf files("ext/")
 
-  testCompile 'junit:junit:4.12'
+  testImplementation 'junit:junit:4.12'
   // Extra proto source files for test besides the ones residing under
   // "src/test".
   testProtobuf files("lib/protos-test.tar.gz")

--- a/testProjectAndroidBase/build_base.gradle
+++ b/testProjectAndroidBase/build_base.gradle
@@ -96,22 +96,22 @@ protobuf {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.squareup.okhttp:okhttp:2.7.5'
-    compile 'javax.annotation:javax.annotation-api:1.2'
-    compile 'com.google.protobuf:protobuf-lite:3.0.0'
-    compile 'io.grpc:grpc-core:1.0.0-pre2'
-    compile 'io.grpc:grpc-stub:1.0.0-pre2'
-    compile 'io.grpc:grpc-okhttp:1.0.0-pre2'
-    compile('io.grpc:grpc-protobuf-lite:1.0.0-pre2') {
-      // Otherwise Android compile will complain "Multiple dex files define ..."
-      exclude module: "protobuf-lite"
-    }
-    compile(project(':testProjectLite')) {
-      exclude module: "protobuf-lite"
-    }
-    protobuf files('lib/protos.jar')
-    testCompile 'junit:junit:4.12'
+  implementation 'com.android.support:appcompat-v7:23.4.0'
+  implementation 'com.squareup.okhttp:okhttp:2.7.5'
+  implementation 'javax.annotation:javax.annotation-api:1.2'
+  implementation 'com.google.protobuf:protobuf-lite:3.0.0'
+  implementation 'io.grpc:grpc-core:1.0.0-pre2'
+  implementation 'io.grpc:grpc-stub:1.0.0-pre2'
+  implementation 'io.grpc:grpc-okhttp:1.0.0-pre2'
+  implementation('io.grpc:grpc-protobuf-lite:1.0.0-pre2') {
+    // Otherwise Android compile will complain "Multiple dex files define ..."
+    exclude module: "protobuf-lite"
+  }
+  implementation(project(':testProjectLite')) {
+    exclude module: "protobuf-lite"
+  }
+  protobuf files('lib/protos.jar')
+  testImplementation 'junit:junit:4.12'
 }
 
 def assertJavaCompileHasProtoGeneratedDir(Object variant, Collection<String> codegenPlugins) {

--- a/testProjectAndroidDependentBase/build_base.gradle
+++ b/testProjectAndroidDependentBase/build_base.gradle
@@ -96,22 +96,22 @@ protobuf {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.squareup.okhttp:okhttp:2.7.5'
-    compile 'javax.annotation:javax.annotation-api:1.2'
-    compile 'com.google.protobuf:protobuf-lite:3.0.0'
-    compile 'io.grpc:grpc-core:1.0.0-pre2'
-    compile 'io.grpc:grpc-stub:1.0.0-pre2'
-    compile 'io.grpc:grpc-okhttp:1.0.0-pre2'
-    compile('io.grpc:grpc-protobuf-lite:1.0.0-pre2') {
+    implementation 'com.android.support:appcompat-v7:23.4.0'
+    implementation 'com.squareup.okhttp:okhttp:2.7.5'
+    implementation 'javax.annotation:javax.annotation-api:1.2'
+    implementation 'com.google.protobuf:protobuf-lite:3.0.0'
+    implementation 'io.grpc:grpc-core:1.0.0-pre2'
+    implementation 'io.grpc:grpc-stub:1.0.0-pre2'
+    implementation 'io.grpc:grpc-okhttp:1.0.0-pre2'
+    implementation('io.grpc:grpc-protobuf-lite:1.0.0-pre2') {
         // Otherwise Android compile will complain "Multiple dex files define ..."
         exclude module: "protobuf-lite"
     }
-    compile(project(':testProjectAndroidLibrary')) {
+    implementation(project(':testProjectAndroidLibrary')) {
         exclude module: "protobuf-lite"
     }
     protobuf files('lib/protos.jar')
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 def assertJavaCompileHasProtoGeneratedDir(Object variant, Collection<String> codegenPlugins) {

--- a/testProjectAndroidKotlinDsl/build.gradle.kts
+++ b/testProjectAndroidKotlinDsl/build.gradle.kts
@@ -130,22 +130,22 @@ protobuf {
 }
 
 dependencies {
-  compile("com.android.support:appcompat-v7:23.4.0")
-  compile("com.squareup.okhttp:okhttp:2.7.5")
-  compile("javax.annotation:javax.annotation-api:1.2")
-  compile("com.google.protobuf:protobuf-lite:3.0.0")
-  compile("io.grpc:grpc-core:1.0.0-pre2")
-  compile("io.grpc:grpc-stub:1.0.0-pre2")
-  compile("io.grpc:grpc-okhttp:1.0.0-pre2")
-  compile("io.grpc:grpc-protobuf-lite:1.0.0-pre2") {
+  implementation("com.android.support:appcompat-v7:23.4.0")
+  implementation("com.squareup.okhttp:okhttp:2.7.5")
+  implementation("javax.annotation:javax.annotation-api:1.2")
+  implementation("com.google.protobuf:protobuf-lite:3.0.0")
+  implementation("io.grpc:grpc-core:1.0.0-pre2")
+  implementation("io.grpc:grpc-stub:1.0.0-pre2")
+  implementation("io.grpc:grpc-okhttp:1.0.0-pre2")
+  implementation("io.grpc:grpc-protobuf-lite:1.0.0-pre2") {
     // Otherwise Android compile will complain "Multiple dex files define ..."
     exclude(module = "protobuf-lite")
   }
-  compile(project(":testProjectLite")) {
+  implementation(project(":testProjectLite")) {
     exclude(module = "protobuf-lite")
   }
   protobuf(files("lib/protos.jar"))
-  testCompile("junit:junit:4.12")
+  testImplementation("junit:junit:4.12")
 }
 
 afterEvaluate {

--- a/testProjectAndroidLibrary/build.gradle
+++ b/testProjectAndroidLibrary/build.gradle
@@ -78,14 +78,14 @@ protobuf {
 }
 
 dependencies {
-    compile 'javax.annotation:javax.annotation-api:1.2'
-    compile 'com.google.protobuf:protobuf-lite:3.0.0'
-    compile 'io.grpc:grpc-core:1.0.0-pre2'
-    compile 'io.grpc:grpc-stub:1.0.0-pre2'
-    compile 'io.grpc:grpc-okhttp:1.0.0-pre2'
-    compile('io.grpc:grpc-protobuf-lite:1.0.0-pre2') {
+    implementation 'javax.annotation:javax.annotation-api:1.2'
+    implementation 'com.google.protobuf:protobuf-lite:3.0.0'
+    implementation 'io.grpc:grpc-core:1.0.0-pre2'
+    implementation 'io.grpc:grpc-stub:1.0.0-pre2'
+    implementation 'io.grpc:grpc-okhttp:1.0.0-pre2'
+    implementation('io.grpc:grpc-protobuf-lite:1.0.0-pre2') {
         // Otherwise Android compile will complain "Multiple dex files define ..."
         exclude module: "protobuf-lite"
     }
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }

--- a/testProjectBase/build_base.gradle
+++ b/testProjectBase/build_base.gradle
@@ -8,13 +8,8 @@ repositories {
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
-configurations {
-    grpcCompile
-}
-
 sourceSets {
   grpc {
-    compileClasspath += configurations.grpcCompile
   }
   test {
     compileClasspath += grpc.output
@@ -29,13 +24,13 @@ dependencies {
   protobuf files("ext/")
   testProtobuf files("lib/protos-test.tar.gz")
 
-  compile protobufDep
-  testCompile 'junit:junit:4.12'
+  implementation protobufDep
+  testImplementation 'junit:junit:4.12'
   // KotlinFooTest.kt requires reflection utilities
-  testCompile "org.jetbrains.kotlin:kotlin-reflect:1.2.0"
-  grpcCompile protobufDep
-  grpcCompile 'io.grpc:grpc-stub:1.0.0-pre2'
-  grpcCompile 'io.grpc:grpc-protobuf:1.0.0-pre2'
+  testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.2.0"
+  grpcImplementation protobufDep
+  grpcImplementation 'io.grpc:grpc-stub:1.0.0-pre2'
+  grpcImplementation 'io.grpc:grpc-protobuf:1.0.0-pre2'
 }
 
 protobuf {

--- a/testProjectBuildTimeProto/build.gradle
+++ b/testProjectBuildTimeProto/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.protobuf:protobuf-java:3.0.0'
+    implementation 'com.google.protobuf:protobuf-java:3.0.0'
 }
 
 sourceSets {

--- a/testProjectCustomProtoDir/build.gradle
+++ b/testProjectCustomProtoDir/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 repositories {
-    maven { url "https://plugins.gradle.org/m2/" }
+  maven { url "https://plugins.gradle.org/m2/" }
 }
 
 sourceSets {
@@ -33,9 +33,9 @@ sourceSets {
 }
 
 dependencies {
-    compile 'com.google.protobuf:protobuf-java:3.0.0'
+  implementation 'com.google.protobuf:protobuf-java:3.0.0'
 
-    testCompile 'junit:junit:4.12'
+  testImplementation 'junit:junit:4.12'
 }
 
 protobuf.protoc {

--- a/testProjectDependent/build.gradle
+++ b/testProjectDependent/build.gradle
@@ -10,14 +10,14 @@ plugins {
 }
 
 repositories {
-    maven { url "https://plugins.gradle.org/m2/" }
+  maven { url "https://plugins.gradle.org/m2/" }
 }
 
 dependencies {
-    compile 'com.google.protobuf:protobuf-java:3.0.0'
-    compile project(':testProject')
+  implementation 'com.google.protobuf:protobuf-java:3.0.0'
+  implementation project(':testProject')
 
-    testCompile 'junit:junit:4.12'
+  testImplementation 'junit:junit:4.12'
 }
 
 protobuf.protoc {

--- a/testProjectKotlinDslBase/build.gradle.kts
+++ b/testProjectKotlinDslBase/build.gradle.kts
@@ -22,19 +22,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_7
 }
 
-val grpcCompile by configurations.creating
-
-the<JavaPluginConvention>().sourceSets {
-
-    val grpc by creating {
-        compileClasspath += grpcCompile
+sourceSets {
+    val grpc = create("grpc") {
     }
 
-    "test"{
+    getByName("test") {
         compileClasspath += grpc.output
         runtimeClasspath += grpc.output
     }
 }
+val grpcImplementation = configurations.getByName("grpcImplementation")
 
 val protobufDep = "com.google.protobuf:protobuf-java:3.0.0"
 
@@ -43,13 +40,13 @@ dependencies {
     protobuf(files("ext/"))
     testProtobuf(files("lib/protos-test.tar.gz"))
 
-    compile(protobufDep)
-    testCompile("junit:junit:4.12")
+    implementation(protobufDep)
+    testImplementation("junit:junit:4.12")
     // KotlinFooTest.kt requires reflection utilities
-    testCompile("org.jetbrains.kotlin:kotlin-reflect:1.2.0")
-    grpcCompile(protobufDep)
-    grpcCompile("io.grpc:grpc-stub:1.0.0-pre2")
-    grpcCompile("io.grpc:grpc-protobuf:1.0.0-pre2")
+    testImplementation("org.jetbrains.kotlin:kotlin-reflect:1.2.0")
+    grpcImplementation(protobufDep)
+    grpcImplementation("io.grpc:grpc-stub:1.0.0-pre2")
+    grpcImplementation("io.grpc:grpc-protobuf:1.0.0-pre2")
 }
 
 protobuf {

--- a/testProjectLite/build.gradle
+++ b/testProjectLite/build.gradle
@@ -13,9 +13,9 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-    compile 'com.google.protobuf:protobuf-lite:3.0.0'
+    implementation 'com.google.protobuf:protobuf-lite:3.0.0'
     protobuf files("ext/")
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 protobuf {


### PR DESCRIPTION
The compile configuration has been deprecated for dependency declaration.
This will fail with an error in Gradle 7.0.