### PR TITLE
Easy migration to CompileStatic annotation

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ArchiveActionFacade.java
+++ b/src/main/groovy/com/google/protobuf/gradle/ArchiveActionFacade.java
@@ -28,18 +28,21 @@
  */
 package com.google.protobuf.gradle;
 
+import groovy.transform.CompileStatic;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileOperations;
 
 import javax.inject.Inject;
 
+@CompileStatic
 public interface ArchiveActionFacade {
 
     FileTree zipTree(Object path);
 
     FileTree tarTree(Object path);
 
+    @CompileStatic
     class ProjectBased implements ArchiveActionFacade {
 
         private final Project project;
@@ -59,6 +62,7 @@ public interface ArchiveActionFacade {
         }
     }
 
+    @CompileStatic
     abstract class ServiceBased implements ArchiveActionFacade {
 
         // TODO Use public ArchiveOperations from Gradle 6.6 instead

--- a/src/main/groovy/com/google/protobuf/gradle/CopyActionFacade.java
+++ b/src/main/groovy/com/google/protobuf/gradle/CopyActionFacade.java
@@ -29,6 +29,7 @@
  */
 package com.google.protobuf.gradle;
 
+import groovy.transform.CompileStatic;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
@@ -42,9 +43,11 @@ import javax.inject.Inject;
  * {@link org.gradle.api.file.FileSystemOperations} if available (Gradle 6.0+) or {@link org.gradle.api.Project#copy} if
  * the version of Gradle is below 6.0.
  */
+@CompileStatic
 interface CopyActionFacade {
     WorkResult copy(Action<? super CopySpec> var1);
 
+    @CompileStatic
     class ProjectBased implements CopyActionFacade {
         private final Project project;
 
@@ -58,6 +61,7 @@ interface CopyActionFacade {
         }
     }
 
+    @CompileStatic
     abstract class FileSystemOperationsBased implements CopyActionFacade {
         @Inject
         public abstract FileSystemOperations getFileSystemOperations();

--- a/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
@@ -28,7 +28,7 @@
  */
 package com.google.protobuf.gradle
 
-import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
 import org.gradle.api.Named
 
 /**
@@ -37,7 +37,7 @@ import org.gradle.api.Named
  * configured, the plugin should try to run the executable from system search
  * path.
  */
-@CompileDynamic
+@CompileStatic
 class ExecutableLocator implements Named {
 
   private final String name

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConvention.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConvention.groovy
@@ -29,7 +29,7 @@
  */
 package com.google.protobuf.gradle
 
-import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.util.ConfigureUtil
@@ -37,7 +37,7 @@ import org.gradle.util.ConfigureUtil
 /**
  * Adds the protobuf {} block as a property of the project.
  */
-@CompileDynamic
+@CompileStatic
 class ProtobufConvention {
     ProtobufConvention(Project project, FileResolver fileResolver) {
         protobuf = new ProtobufConfigurator(project, fileResolver)

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -30,7 +30,7 @@
 package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
-import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DuplicatesStrategy
@@ -54,7 +54,7 @@ import javax.inject.Inject
 /**
  * Extracts proto files from a dependency configuration.
  */
-@CompileDynamic
+@CompileStatic
 abstract class ProtobufExtract extends DefaultTask {
 
   /**
@@ -171,7 +171,7 @@ abstract class ProtobufExtract extends DefaultTask {
         } else if (file.path.endsWith('.jar') || file.path.endsWith('.zip')) {
           protoInputs.add(archiveFacade.zipTree(file.path).matching(protoFilter))
         } else if (file.path.endsWith('.aar')) {
-          FileCollection zipTree = archiveFacade.zipTree(file.path).filter { it.path.endsWith('.jar') }
+          FileCollection zipTree = archiveFacade.zipTree(file.path).filter { File it -> it.path.endsWith('.jar') }
           zipTree.each { entry ->
             protoInputs.add(archiveFacade.zipTree(entry).matching(protoFilter))
           }

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -29,7 +29,7 @@
 package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
-import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -43,7 +43,7 @@ import java.util.regex.Matcher
 /**
  * Utility classes.
  */
-@CompileDynamic
+@CompileStatic
 class Utils {
   /**
    * Returns the conventional name of a configuration for a sourceSet


### PR DESCRIPTION
If groovy compiles without CompileStatic - code will be compiled in dynamic way,
e.g. All type checks will be in runtime. Erased types in bytecode.
With CompileStatic - compiler will save all typed in bytecode.
If all types saved, we can do static analysis of bytecode with java 8 capability.
More details can be found here: https://github.com/google/protobuf-gradle-plugin/pull/565#issuecomment-1159752656