### PR TITLE
Convert more classes to CompileStatic

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -363,7 +363,8 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @InputFiles
   @PathSensitive(PathSensitivity.NONE)
   FileCollection getSnapshotArtifacts() {
-    Provider<Collection<FileCollection>> snapshotArtifacts = locatorToAlternativePathsMapping.map { Map<String, FileCollection> map ->
+    Provider<Collection<FileCollection>> snapshotArtifacts = locatorToAlternativePathsMapping.map {
+        Map<String, FileCollection> map ->
       Set<String> releaseArtifactKeys = releaseDependenciesMapping.get().keySet()
       map.findAll { entry ->
         !releaseArtifactKeys.contains(entry.key)

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufConfigurator.groovy
@@ -28,7 +28,9 @@
  */
 package com.google.protobuf.gradle
 
-import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
 import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.tasks.TaskCollection
@@ -37,7 +39,7 @@ import org.gradle.util.ConfigureUtil
 /**
  * The main configuration block exposed as {@code protobuf} in the build script.
  */
-@CompileDynamic
+@CompileStatic
 public class ProtobufConfigurator {
   private final Project project
   private final GenerateProtoTaskCollection tasks
@@ -135,6 +137,7 @@ public class ProtobufConfigurator {
       }
     }
 
+    @TypeChecked(TypeCheckingMode.SKIP) // Don't depend on AGP
     public TaskCollection<GenerateProtoTask> ofVariant(String variant) {
       return all().matching { GenerateProtoTask task ->
         task.variant.name == variant


### PR DESCRIPTION
As a solution to use AnimalSniffer to detect incompatibilities with
Java 8, as discussed at
https://github.com/google/protobuf-gradle-plugin/pull/565#issuecomment-1159752656

CC @rougsig