### PR TITLE
Release 0.8.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ buildscript {
     mavenLocal()
   }
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.19-SNAPSHOT'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.0-SNAPSHOT'
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more information about the Protobuf Compiler, please refer to
 [Google Developers Site](https://developers.google.com/protocol-buffers/docs/reference/java-generated?csw=1).
 
 ## Latest Version
-The latest version is ``0.8.18``. It requires at least __Gradle 5.6__ and __Java 8__.
+The latest version is ``0.8.19``. It requires at least __Gradle 5.6__ and __Java 8__.
 It is available on Maven Central. To add dependency to it:
 ```gradle
 buildscript {
@@ -25,7 +25,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.18'
+    classpath 'gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.19'
   }
 }
 ```
@@ -81,7 +81,7 @@ The order of the plugins doesn't matter:
 
 ```gradle
 plugins {
-  id "com.google.protobuf" version "0.8.18"
+  id "com.google.protobuf" version "0.8.19"
   id "java"
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.github.ben-manes.versions'
 
 group = 'com.google.protobuf'
-version = '0.8.19-SNAPSHOT'
+version = '0.8.19'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.github.ben-manes.versions'
 
 group = 'com.google.protobuf'
-version = '0.8.19'
+version = '0.9.0-SNAPSHOT'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
#565 is changing some core parts of how we release, so it seems fair to bump the minor version for the next release. Doing that now instead of as a separate step later.

I'll merge this using the command line, not github.