### PR TITLE
Remove gradle.plugin from coordinates for recent release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'gradle.plugin.com.google.protobuf:protobuf-gradle-plugin:0.8.19'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.19'
   }
 }
 ```


### PR DESCRIPTION
5eade538 inadvertently changed the coordinates used for the plugin from
gradle.plugin.com.google.protobuf:protobuf-gradle-plugin to
com.google.protobuf:protobuf-gradle-plugin. This is because simply
adding the maven-publish plugin changes plugin-publish's behavior
(https://github.com/gradle/plugin-portal-requests/issues/124).

Although this was accidental, this does seem to be the way things are
supposed to work going forward as later versions of the plugin-publish
than we are using always include maven-publish and the
`mavenCoordinates` override block was removed
https://plugins.gradle.org/plugin/com.gradle.plugin-publish/1.0.0 .