### PR TITLE
Easy part of gradle task avoidance api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,3 +196,9 @@ tasks.named('compileGroovy') {
 tasks.named('compileKotlin') {
     compileKotlin.classpath += files(compileGroovy.destinationDirectory)
 }
+
+test {
+  testLogging {
+    events = ["standard_out", "standard_error", "started", "passed", "failed", "skipped"]
+  }
+}

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -30,6 +30,8 @@ package com.google.protobuf.gradle
 
 import com.google.common.base.Preconditions
 import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
 import org.apache.commons.lang.StringUtils
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -125,6 +127,7 @@ class Utils {
    * Adds the file to the IDE plugin's set of sources / resources. If the directory does
    * not exist, it will be created before the IDE task is run.
    */
+  @TypeChecked(TypeCheckingMode.SKIP) // For unknown reasons, configureEach (L:144) contains Object in closure
   static void addToIdeSources(Project project, boolean isTest, File f, boolean isGenerated) {
     project.plugins.withId("idea") {
       IdeaModel model = project.getExtensions().findByType(IdeaModel)
@@ -136,8 +139,8 @@ class Utils {
       if (isGenerated) {
         model.module.generatedSourceDirs += f
       }
-      project.tasks.withType(GenerateIdeaModule).each {
-        it.doFirst {
+      project.tasks.withType(GenerateIdeaModule).configureEach { GenerateIdeaModule task ->
+        task.doFirst {
           // This is required because the intellij plugin does not allow adding source directories
           // that do not exist. The intellij config files should be valid from the start even if a
           // user runs './gradlew idea' before running './gradlew generateProto'.


### PR DESCRIPTION
**Background:**
Plugin creates eagerly creates tasks.
More details can be found here. https://github.com/google/protobuf-gradle-plugin/issues/304

**Changes:**
Replaced eager functions with lazy analogs.
<details>
  <summary>Before, gradle scan (16 tasks created):</summary>
  
![image](https://user-images.githubusercontent.com/18681794/176929258-68f24857-5f54-4b47-a360-1960781b5439.png)  
</details>

<details>
  <summary>After, gradle scan (9 tasks created):</summary>
  
![image](https://user-images.githubusercontent.com/18681794/176929274-b2249bc7-e546-4965-bd91-02b5eb3c84c0.png)
</details>

**Test plan:**
Green pipelines, production code was not changed.
(Actually changed the production code but not the business logic)
