### PR TITLE
Avoid pushing executable configuration into task

### DIFF
--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -33,7 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <ruleset-ref path='rulesets/basic.xml'/>
   <ruleset-ref path='rulesets/braces.xml'/>
   <ruleset-ref path='rulesets/concurrency.xml'/>
-  <ruleset-ref path='rulesets/convention.xml'/>
+  <ruleset-ref path='rulesets/convention.xml'>
+    <exclude name="PublicMethodsBeforeNonPublicMethods"/>
+  </ruleset-ref>
   <ruleset-ref path='rulesets/design.xml'>
     <exclude name="Instanceof"/>
     <exclude name="ImplementationAsType"/>

--- a/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
@@ -28,8 +28,11 @@
  */
 package com.google.protobuf.gradle
 
+import com.google.common.base.Preconditions
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import org.gradle.api.Named
+import org.gradle.api.file.FileCollection
 
 /**
  * Locates an executable that can either be found locally or downloaded from
@@ -44,6 +47,9 @@ class ExecutableLocator implements Named {
 
   private String artifact
   private String path
+
+  private FileCollection artifactFiles
+  private String simplifiedArtifactName
 
   ExecutableLocator(String name) {
     this.name = name
@@ -77,5 +83,25 @@ class ExecutableLocator implements Named {
 
   String getPath() {
     return path
+  }
+
+  @PackageScope
+  FileCollection getArtifactFiles() {
+    Preconditions.checkState(path == null, 'Not artifact based')
+    Preconditions.checkState(artifactFiles != null, 'Not yet created resolved')
+    return artifactFiles
+  }
+
+  @PackageScope
+  String getSimplifiedArtifactName() {
+    Preconditions.checkState(path == null, 'Not artifact based')
+    Preconditions.checkState(simplifiedArtifactName != null, 'Not yet resolved')
+    return simplifiedArtifactName
+  }
+
+  @PackageScope
+  void resolve(FileCollection artifactFiles, String simplifiedArtifactName) {
+    this.artifactFiles = artifactFiles
+    this.simplifiedArtifactName = simplifiedArtifactName
   }
 }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableList
 import groovy.transform.CompileDynamic
 import org.gradle.api.Action
 import org.gradle.api.GradleException
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -165,7 +164,7 @@ class ProtobufPlugin implements Plugin<Project> {
           postConfigure.each { it.call() }
           // protoc and codegen plugin configuration may change through the protobuf{}
           // block. Only at this point the configuration has been finalized.
-          this.protobufExtension.tools.registerTaskDependencies(this.protobufExtension.generateProtoTasks.all())
+          project.protobuf.tools.resolve(project)
 
           // Register proto and generated sources with IDE
           addSourcesToIde(isAndroid)
@@ -363,10 +362,6 @@ class ProtobufPlugin implements Plugin<Project> {
           SourceDirectorySet protoSrcDirSet = sourceSet.proto
           addIncludeDir(protoSrcDirSet.sourceDirectories)
         }
-        protocLocator.set(project.providers.provider { this.protobufExtension.tools.protoc })
-        pluginsExecutableLocators.set(project.providers.provider {
-            ((NamedDomainObjectContainer<ExecutableLocator>) this.protobufExtension.tools.plugins).asMap
-        })
       }
     }
 


### PR DESCRIPTION
Having GenerateProtoTask grab data when needed from ToolsLocator removes
lots of indirection, and plumbing by the plugin. The main reason for the
indirection is that ToolsLocator can't contain Project for
configuration caching to function, so we remove Project from
ToolsLocator.

---

This removes the looping over the tasks in registerTaskDependencies().