### PR TITLE
Avoid explicit dependsOn(ProtobufExtract)

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -125,7 +125,6 @@ abstract class ProtobufExtract extends DefaultTask {
   protected void setDestDir(File destDir) {
     Preconditions.checkState(this.destDir == null, 'destDir already set')
     this.destDir = destDir
-    outputs.dir destDir
   }
 
   @OutputDirectory

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -256,7 +256,7 @@ class ProtobufPlugin implements Plugin<Project> {
         java { }
       }
 
-      Task extractTask = setupExtractProtosTask(generateProtoTask, sourceSet.name)
+      setupExtractProtosTask(generateProtoTask, sourceSet.name)
       setupExtractIncludeProtosTask(generateProtoTask, sourceSet.name)
 
       // Include source proto files in the compiled archive, so that proto files from
@@ -266,7 +266,6 @@ class ProtobufPlugin implements Plugin<Project> {
       processResourcesTask.from(generateProtoTask.sourceFiles) {
         include '**/*.proto'
       }
-      processResourcesTask.dependsOn(extractTask)
 
       SUPPORTED_LANGUAGES.each { String lang ->
         linkGenerateProtoTasksToTaskName(sourceSet.getCompileTaskName(lang), generateProtoTask)
@@ -311,14 +310,9 @@ class ProtobufPlugin implements Plugin<Project> {
           processResourcesTask.from(generateProtoTask.sourceFiles) {
               include '**/*.proto'
           }
-          variant.sourceSets.each {
-              Task extractTask = setupExtractProtosTask(generateProtoTask, it.name)
-              processResourcesTask.dependsOn(extractTask)
-          }
-      } else {
-          variant.sourceSets.each {
-              setupExtractProtosTask(generateProtoTask, it.name)
-          }
+      }
+      variant.sourceSets.each {
+        setupExtractProtosTask(generateProtoTask, it.name)
       }
       if (isTestVariant) {
         // unit test variants do not implement registerJavaGeneratingTask
@@ -392,7 +386,7 @@ class ProtobufPlugin implements Plugin<Project> {
       }
 
       linkExtractTaskToGenerateTask(task, generateProtoTask)
-      generateProtoTask.addSourceFiles(project.fileTree(task.destDir) { include "**/*.proto" })
+      generateProtoTask.addSourceFiles(project.fileTree(task) { include "**/*.proto" })
       return task
     }
 
@@ -448,8 +442,7 @@ class ProtobufPlugin implements Plugin<Project> {
     }
 
     private void linkExtractTaskToGenerateTask(ProtobufExtract extractTask, GenerateProtoTask generateTask) {
-      generateTask.dependsOn(extractTask)
-      generateTask.addIncludeDir(project.files(extractTask.destDir))
+      generateTask.addIncludeDir(project.files(extractTask))
     }
 
     private void linkGenerateProtoTasksToTaskName(String compileTaskName, GenerateProtoTask genProtoTask) {


### PR DESCRIPTION
ProtobufExtract only has only output directory, so using the task
outputs is trivial and propagates the dependency implicitly.