### PR TITLE
Avoid explicit dependsOn(GenerateProtoTask)

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -602,9 +602,9 @@ public abstract class GenerateProtoTask extends DefaultTask {
     String srcSetName = "generate-proto-" + name
     SourceDirectorySet srcSet
     srcSet = objectFactory.sourceDirectorySet(srcSetName, srcSetName)
-    srcSet.srcDirs providerFactory.provider {
+    srcSet.srcDirs objectFactory.fileCollection().builtBy(this).from(providerFactory.provider {
       getOutputSourceDirectories()
-    }
+    })
     return srcSet
   }
 

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -123,7 +123,6 @@ class ProtobufPlugin implements Plugin<Project> {
     }
 
     private static void linkGenerateProtoTasksToTask(Task task, GenerateProtoTask genProtoTask) {
-      task.dependsOn(genProtoTask)
       task.source genProtoTask.getOutputSourceDirectorySet().include("**/*.java", "**/*.kt")
     }
 


### PR DESCRIPTION
The FileCollection can propagate the dependency information implicitly.