### PR TITLE
Remove generate proto task link to compile on

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -34,7 +34,6 @@ import static java.nio.charset.StandardCharsets.US_ASCII
 import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
 import groovy.transform.CompileStatic
-import groovy.transform.PackageScope
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.Action
@@ -45,7 +44,6 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
-import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
@@ -60,13 +58,13 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.OutputDirectories
 
 import javax.annotation.Nullable
 import javax.inject.Inject
@@ -256,11 +254,6 @@ public abstract class GenerateProtoTask extends DefaultTask {
     checkInitializing()
     Preconditions.checkState(this.outputBaseDir == null, 'outputBaseDir is already set')
     this.outputBaseDir = outputBaseDir
-  }
-
-  @OutputDirectory
-  String getOutputBaseDir() {
-    return outputBaseDir.get()
   }
 
   void setSourceSet(SourceSet sourceSet) {
@@ -593,23 +586,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
     return "${outputBaseDir.get()}/${plugin.outputSubDir}"
   }
 
-  /**
-   * Returns a {@code SourceDirectorySet} representing the generated source
-   * directories.
-   */
-  @Internal
-  SourceDirectorySet getOutputSourceDirectorySet() {
-    String srcSetName = "generate-proto-" + name
-    SourceDirectorySet srcSet
-    srcSet = objectFactory.sourceDirectorySet(srcSetName, srcSetName)
-    srcSet.srcDirs providerFactory.provider {
-      getOutputSourceDirectories()
-    }
-    return srcSet
-  }
-
-  @Internal
-  @PackageScope
+  @OutputDirectories
   Collection<File> getOutputSourceDirectories() {
     Collection<File> srcDirs = []
     builtins.each { builtin ->

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -308,8 +308,15 @@ class ProtobufPlugin implements Plugin<Project> {
           }
       }
       postConfigure.add {
-        // This cannot be called once task execution has started.
+        // This cannot be called once task execution has start
         variant.registerJavaGeneratingTask(generateProtoTask, generateProtoTask.getOutputSourceDirectories())
+
+        // registerJavaGeneratingTask do nothing with kotlin tasks. It's works only with java.
+        Task kotlinCompileTask =  project.tasks.findByName("compile${variant.name.capitalize()}Kotlin")
+        if (kotlinCompileTask != null) {
+          kotlinCompileTask.dependsOn(generateProtoTask)
+          kotlinCompileTask.source(generateProtoTask.getOutputSourceDirectories())
+        }
       }
     }
 
@@ -442,28 +449,21 @@ class ProtobufPlugin implements Plugin<Project> {
       // The generated javalite sources have lint issues. This is fixed upstream but
       // there is still no release with the fix yet.
       //   https://github.com/google/protobuf/pull/2823
-      if (isAndroid) {
-        // variant.registerJavaGeneratingTask called earlier already registers the generated
-        // sources for normal variants, but unit test variants work differently and do not
-        // use registerJavaGeneratingTask. Let's call addJavaSourceFoldersToModel for all tasks
-        // to ensure all variants (including unit test variants) have sources registered.
-        project.tasks.withType(GenerateProtoTask).each { GenerateProtoTask generateProtoTask ->
-          generateProtoTask.variant.addJavaSourceFoldersToModel(generateProtoTask.getOutputSourceDirectories())
-        }
 
-        // TODO(zpencer): add gen sources from cross project GenerateProtoTasks
-        // This is an uncommon project set up but it is possible.
-        // We must avoid using private android APIs to find subprojects that the variant depends
-        // on, such as by walking through
-        //   variant.variantData.variantDependency.compileConfiguration.allDependencies
-        // Gradle.getTaskGraph().getDependencies() should allow us to walk the task graph,
-        // but unfortunately that API is @Incubating. We can revisit it when it becomes stable.
-        // https://docs.gradle.org/4.8/javadoc/org/gradle/api/execution/
-        // TaskExecutionGraph.html#getDependencies-org.gradle.api.Task-
+      // TODO(zpencer): add gen sources from cross project GenerateProtoTasks
+      // This is an uncommon project set up but it is possible.
+      // We must avoid using private android APIs to find subprojects that the variant depends
+      // on, such as by walking through
+      //   variant.variantData.variantDependency.compileConfiguration.allDependencies
+      // Gradle.getTaskGraph().getDependencies() should allow us to walk the task graph,
+      // but unfortunately that API is @Incubating. We can revisit it when it becomes stable.
+      // https://docs.gradle.org/4.8/javadoc/org/gradle/api/execution/
+      // TaskExecutionGraph.html#getDependencies-org.gradle.api.Task-
 
-        // TODO(zpencer): find a way to make android studio aware of the .proto files
-        // Simply adding the .proto dirs via addJavaSourceFoldersToModel does not seem to work.
-      } else {
+      // TODO(zpencer): find a way to make android studio aware of the .proto files
+      // Simply adding the .proto dirs via addJavaSourceFoldersToModel does not seem to work.
+
+      if (!isAndroid) {
         // Make the proto source dirs known to IDEs
         project.sourceSets.each { sourceSet ->
           SourceDirectorySet protoSrcDirSet = sourceSet.proto

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -147,6 +147,28 @@ class Utils {
     }
   }
 
+  /**
+   * For each variant, agp creates a unique source set.
+   * The variant does not have a property to get a unique source set.
+   * For that reason, map the variant name to the source set name to find a unique source set.
+   *
+   * Patterns (variant -> sourceSet):
+   * <FLAVOUR><BUILD_TYPE> -> <FLAVOUR><BUILD_TYPE>
+   * <FLAVOUR><BUILD_TYPE>UnitTest -> test<FLAVOUR><BUILD_TYPE>
+   * <FLAVOUR><BUILD_TYPE>AndroidTest -> androidTest<FLAVOUR><BUILD_TYPE>
+   *
+   * @param variantName
+   * @return
+   */
+  public static String variantNameToSourceSetName(final String variantName) {
+    if (variantName.endsWith("UnitTest")) {
+      return "test${variantName.replace("UnitTest", "").capitalize()}"
+    } else if (variantName.endsWith("AndroidTest")) {
+      return "androidTest${variantName.replace("AndroidTest", "").capitalize()}"
+    }
+    return variantName
+  }
+
   private static Matcher parseVersionString(String version) {
     Matcher matcher = version =~ "(\\d*)\\.(\\d*).*"
     if (!matcher || !matcher.matches()) {


### PR DESCRIPTION
Java/kotlin: compile task implicit depends on generate proto task via source sets
Android: compile tasks depends on generate proto task via registerJavaGeneratingTask