### PR TITLE
Migrate ProtobufExtract task to lazy configuration api

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -65,16 +65,22 @@ abstract class ProtobufExtract extends DefaultTask {
   @OutputDirectory
   public abstract DirectoryProperty getDestDir()
 
-  // Used to configure ide proto sources
+  /**
+   * Used to configure ide proto sources.
+   */
   @Internal
   public abstract Property<Boolean> getIsTest()
 
-  // Input tracked in getInputProtoFiles method
+  /**
+   * Input for this tasks containing all archive files to extract.
+   */
   @Internal
   public abstract ConfigurableFileCollection getInputFiles()
 
-  // Inputs for this task containing only proto files, which is enough for up-to-date checks.
-  // Add inputs to inputFiles. Uses relative path sensitivity as directory layout changes impact output.
+  /**
+   * Inputs for this task containing only proto files, which is enough for up-to-date checks.
+   * Add inputs to inputFiles. Uses relative path sensitivity as directory layout changes impact output.
+   */
   @InputFiles
   @PathSensitive(PathSensitivity.RELATIVE)
   public FileTree getInputProtoFiles() {
@@ -98,6 +104,22 @@ abstract class ProtobufExtract extends DefaultTask {
 
   @Inject
   protected abstract ProviderFactory getProviderFactory()
+
+  private CopyActionFacade instantiateCopyActionFacade() {
+    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
+      // Use object factory to instantiate as that will inject the necessary service.
+      return objectFactory.newInstance(CopyActionFacade.FileSystemOperationsBased)
+    }
+    return new CopyActionFacade.ProjectBased(project)
+  }
+
+  private ArchiveActionFacade instantiateArchiveActionFacade() {
+    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
+      // Use object factory to instantiate as that will inject the necessary service.
+      return objectFactory.newInstance(ArchiveActionFacade.ServiceBased)
+    }
+    return new ArchiveActionFacade.ProjectBased(project)
+  }
 
   private FileCollection instantiateFilteredProtos() {
     boolean warningLogged = false
@@ -146,19 +168,4 @@ abstract class ProtobufExtract extends DefaultTask {
       })
   }
 
-  private CopyActionFacade instantiateCopyActionFacade() {
-    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
-      // Use object factory to instantiate as that will inject the necessary service.
-      return objectFactory.newInstance(CopyActionFacade.FileSystemOperationsBased)
-    }
-    return new CopyActionFacade.ProjectBased(project)
-  }
-
-  private ArchiveActionFacade instantiateArchiveActionFacade() {
-    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
-      // Use object factory to instantiate as that will inject the necessary service.
-      return objectFactory.newInstance(ArchiveActionFacade.ServiceBased)
-    }
-    return new ArchiveActionFacade.ProjectBased(project)
-  }
 }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -129,43 +129,42 @@ abstract class ProtobufExtract extends DefaultTask {
     // the dependency it provides, but then provide the files we actually care about in our own
     // provider. https://github.com/google/protobuf-gradle-plugin/issues/550
     return objectFactory.fileCollection()
-      .from(inputFiles.filter { false })
-      .from(providerFactory.provider { unused ->
-        Set<File> files = inputFiles.files
-        PatternSet protoFilter = new PatternSet().include("**/*.proto")
-        Set<Object> protoInputs = [] as Set
-        for (File file : files) {
-          if (file.isDirectory()) {
-            protoInputs.add(file)
-          } else if (file.path.endsWith('.proto')) {
-            if (!warningLogged) {
-              warningLogged = true
-              logger.warn "proto file '${file.path}' directly specified in configuration. " +
-                "It's likely you specified files('path/to/foo.proto') or " +
-                "fileTree('path/to/directory') in protobuf or compile configuration. " +
-                "This makes you vulnerable to " +
-                "https://github.com/google/protobuf-gradle-plugin/issues/248. " +
-                "Please use files('path/to/directory') instead."
-            }
-            protoInputs.add(file)
-          } else if (file.path.endsWith('.jar') || file.path.endsWith('.zip')) {
-            protoInputs.add(archiveFacade.zipTree(file.path).matching(protoFilter))
-          } else if (file.path.endsWith('.aar')) {
-            FileCollection zipTree = archiveFacade.zipTree(file.path).filter { File it -> it.path.endsWith('.jar') }
-            zipTree.each { entry ->
-              protoInputs.add(archiveFacade.zipTree(entry).matching(protoFilter))
-            }
-          } else if (file.path.endsWith('.tar')
-            || file.path.endsWith('.tar.gz')
-            || file.path.endsWith('.tar.bz2')
-            || file.path.endsWith('.tgz')) {
-            protoInputs.add(archiveFacade.tarTree(file.path).matching(protoFilter))
-          } else {
-            logger.debug "Skipping unsupported file type (${file.path}); handles only jar, tar, tar.gz, tar.bz2 & tgz"
+        .from(inputFiles.filter { false })
+        .from(providerFactory.provider { unused ->
+      Set<File> files = inputFiles.files
+      PatternSet protoFilter = new PatternSet().include("**/*.proto")
+      Set<Object> protoInputs = [] as Set
+      for (File file : files) {
+        if (file.isDirectory()) {
+          protoInputs.add(file)
+        } else if (file.path.endsWith('.proto')) {
+          if (!warningLogged) {
+            warningLogged = true
+            logger.warn "proto file '${file.path}' directly specified in configuration. " +
+                    "It's likely you specified files('path/to/foo.proto') or " +
+                    "fileTree('path/to/directory') in protobuf or compile configuration. " +
+                    "This makes you vulnerable to " +
+                    "https://github.com/google/protobuf-gradle-plugin/issues/248. " +
+                    "Please use files('path/to/directory') instead."
           }
+          protoInputs.add(file)
+        } else if (file.path.endsWith('.jar') || file.path.endsWith('.zip')) {
+          protoInputs.add(archiveFacade.zipTree(file.path).matching(protoFilter))
+        } else if (file.path.endsWith('.aar')) {
+          FileCollection zipTree = archiveFacade.zipTree(file.path).filter { File it -> it.path.endsWith('.jar') }
+          zipTree.each { entry ->
+            protoInputs.add(archiveFacade.zipTree(entry).matching(protoFilter))
+          }
+        } else if (file.path.endsWith('.tar')
+                || file.path.endsWith('.tar.gz')
+                || file.path.endsWith('.tar.bz2')
+                || file.path.endsWith('.tgz')) {
+          protoInputs.add(archiveFacade.tarTree(file.path).matching(protoFilter))
+        } else {
+          logger.debug "Skipping unsupported file type (${file.path}); handles only jar, tar, tar.gz, tar.bz2 & tgz"
         }
-        return protoInputs
-      })
+      }
+      return protoInputs
+    })
   }
-
 }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -40,7 +40,6 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -66,16 +65,16 @@ abstract class ProtobufExtract extends DefaultTask {
   @OutputDirectory
   public abstract DirectoryProperty getDestDir()
 
-  @Input
+  // Used to configure ide proto sources
+  @Internal
   public abstract Property<Boolean> getIsTest()
 
+  // Input tracked in getInputProtoFiles method
   @Internal
   public abstract ConfigurableFileCollection getInputFiles()
 
-  /**
-   * Inputs for this task containing only proto files, which is enough for up-to-date checks.
-   * Add inputs to inputFiles. Uses relative path sensitivity as directory layout changes impact output.
-   */
+  // Inputs for this task containing only proto files, which is enough for up-to-date checks.
+  // Add inputs to inputFiles. Uses relative path sensitivity as directory layout changes impact output.
   @InputFiles
   @PathSensitive(PathSensitivity.RELATIVE)
   public FileTree getInputProtoFiles() {

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -382,13 +382,13 @@ class ProtobufPlugin implements Plugin<Project> {
     private Task setupExtractProtosTask(final GenerateProtoTask generateProtoTask, final String sourceSetName) {
       String extractProtosTaskName = 'extract' +
           Utils.getSourceSetSubstringForTaskNames(sourceSetName) + 'Proto'
-      Task task = project.tasks.findByName(extractProtosTaskName)
+      ProtobufExtract task = project.tasks.findByName(extractProtosTaskName)
       if (task == null) {
         task = project.tasks.create(extractProtosTaskName, ProtobufExtract) {
           description = "Extracts proto files/dependencies specified by 'protobuf' configuration"
-          destDir = getExtractedProtosDir(sourceSetName) as File
+          destDir.set(getExtractedProtosDir(sourceSetName) as File)
           inputFiles.from(project.configurations[Utils.getConfigName(sourceSetName, 'protobuf')])
-          isTest = Utils.isTest(sourceSetName)
+          isTest.set(Utils.isTest(sourceSetName))
         }
       }
 
@@ -514,7 +514,7 @@ class ProtobufPlugin implements Plugin<Project> {
         }
         // Make the extracted proto dirs known to IDEs
         project.tasks.withType(ProtobufExtract).each { ProtobufExtract extractProtoTask ->
-          Utils.addToIdeSources(project, extractProtoTask.isTest, extractProtoTask.destDir, true)
+          Utils.addToIdeSources(project, extractProtoTask.isTest.get(), extractProtoTask.destDir.get().asFile, true)
         }
         // Make the generated code dirs known to IDEs
         project.tasks.withType(GenerateProtoTask).each { GenerateProtoTask generateProtoTask ->


### PR DESCRIPTION
Background:
Fix for https://github.com/google/protobuf-gradle-plugin/issues/537

Changes:
Migrate ProtobufExtract task to [gradle lazy configuration api](https://docs.gradle.org/current/userguide/lazy_configuration.html#lazy_properties).
Mark necessary properties with `Input`, `Internal`, `OutputDirectory`, etc annotations

Test plan:
Green pipelines, production code logic was not changed. Check build deprecations with `--warning-mode=all`

IMPORTANT NOTES:
`ProtobufExtract` api was changed. Its breaking change. In reason of `ProtobufExtract` is internal use, there shouldn't be any problems.