### PR TITLE
Add the generated source folders to Eclipse classpath entries

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -487,6 +487,8 @@ class ProtobufPlugin implements Plugin<Project> {
         project.tasks.withType(GenerateProtoTask).each { GenerateProtoTask generateProtoTask ->
           generateProtoTask.getOutputSourceDirectories().each { File outputDir ->
             Utils.addToIdeSources(project, generateProtoTask.isTest, outputDir, true)
+            Utils.addToEclipseSources(project, generateProtoTask.isTest,
+                    generateProtoTask.sourceSet.name, outputDir)
           }
         }
       }

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -157,9 +157,6 @@ class Utils {
         entry.entryAttributes.put("optional", "true")
         entry.entryAttributes.put("ignore_optional_problems", "true")
 
-        entry.entryAttributes.put("gradle_scope", isTest ? "test" : "main")
-        entry.entryAttributes.put("gradle_used_by_scope", isTest ? "test" : "main,test")
-
         // this attribute is optional, but it could be useful for IDEs to recognize that it is
         // generated source folder from protobuf, thus providing some support for that.
         // e.g. Hint user to run generate tasks if the folder is empty or does not exist.

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -156,6 +156,15 @@ class Utils {
         SourceFolder entry = new SourceFolder(relativePath, getOutputPath(cp, sourceSetName))
         entry.entryAttributes.put("optional", "true")
         entry.entryAttributes.put("ignore_optional_problems", "true")
+
+        entry.entryAttributes.put("gradle_scope", isTest ? "test" : "main")
+        entry.entryAttributes.put("gradle_used_by_scope", isTest ? "test" : "main,test")
+
+        // this attribute is optional, but it could be useful for IDEs to recognize that it is
+        // generated source folder from protobuf, thus providing some support for that.
+        // e.g. Hint user to run generate tasks if the folder is empty or does not exist.
+        entry.entryAttributes.put("protobuf_generated_source", "true")
+
         // check if output is not null here because test source folder
         // must have a separate output folder in Eclipse
         if (entry.output != null && isTest) {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -442,9 +442,9 @@ class ProtobufJavaPluginTest extends Specification {
       if (path.startsWith("build/generated/source/proto")) {
         if (path.contains("test")) {
           // test source path has one more attribute: ["test"="true"]
-          assert it.attributes.attribute.size() == 6
+          assert it.attributes.attribute.size() == 4
         } else {
-          assert it.attributes.attribute.size() == 5
+          assert it.attributes.attribute.size() == 3
         }
       }
     }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -437,7 +437,16 @@ class ProtobufJavaPluginTest extends Specification {
 
     Set<String> sourceDir = [] as Set
     srcEntries.each {
-        sourceDir.add(it.@path)
+      String path = it.@path
+      sourceDir.add(path)
+      if (path.startsWith("build/generated/source/proto")) {
+        if (path.contains("test")) {
+          // test source path has one more attribute: ["test"="true"]
+          assert it.attributes.attribute.size() == 6
+        } else {
+          assert it.attributes.attribute.size() == 5
+        }
+      }
     }
 
     Set<String> expectedSourceDir = ImmutableSet.builder()

--- a/testProject/build.gradle
+++ b/testProject/build.gradle
@@ -3,6 +3,7 @@
 plugins {
   id 'java'
   id 'idea'
+  id 'eclipse'
   id 'com.google.protobuf'
 }
 apply from: 'build_base.gradle'


### PR DESCRIPTION
- add the generated source folders to Eclipse classpath entries. Due to
  a limition of Buildship, we have to create those folders beforehand,
  see: https://github.com/eclipse/buildship/issues/1196

Signed-off-by: sheche <sheche@microsoft.com>