### PR TITLE
Add source sets

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -68,11 +68,6 @@ class ProtobufPlugin implements Plugin<Project> {
             'android-library',
     ]
 
-    private static final List<String> SUPPORTED_LANGUAGES = [
-        'java',
-        'kotlin',
-    ]
-
     private Project project
     private ProtobufExtension protobufExtension
     private boolean wasApplied = false

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -252,6 +252,8 @@ class ProtobufPlugin implements Plugin<Project> {
       generateProtoTask.doneInitializing()
       generateProtoTask.builtins.maybeCreate("java")
 
+      sourceSet.java.source(generateProtoTask.getOutputSourceDirectorySet())
+
       setupExtractProtosTask(generateProtoTask, sourceSet.name)
       setupExtractIncludeProtosTask(generateProtoTask, sourceSet.name)
 
@@ -261,10 +263,6 @@ class ProtobufPlugin implements Plugin<Project> {
           project.tasks.getByName(sourceSet.getTaskName('process', 'resources')) as ProcessResources
       processResourcesTask.from(generateProtoTask.sourceDirs) { CopySpec it ->
         it.include '**/*.proto'
-      }
-
-      SUPPORTED_LANGUAGES.each { String lang ->
-        linkGenerateProtoTasksToTaskName(sourceSet.getCompileTaskName(lang), generateProtoTask)
       }
     }
 


### PR DESCRIPTION
Background:
Generated code was not in sourceSets. This is a problem for the task configuration. For example, the jar task does not package generated proto class.

Changes:
Add generateProtoTask to java sourceSet.

Test plan:
Green pipelines, production code logic was not changed.