### PR TITLE
When applying plugin, pass dependencies instead of dependents

### DIFF
--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
@@ -10,8 +10,8 @@ import spock.lang.Unroll
 
 @CompileDynamic
 class ProtobufAndroidPluginKotlinTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6", "6.5-milestone-1", "7.4.2"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0-alpha10", "7.2.1"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5.1", "7.4.2"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "7.2.1"]
   private static final List<String> KOTLIN_VERSION = ["1.3.20", "1.3.20", "1.3.40"]
 
   /**

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -15,7 +15,7 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufAndroidPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6", "6.5", "6.8", "7.4.2"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5.1", "6.8", "7.4.2"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "4.2.0-alpha10", "7.2.1"]
 
   @Unroll

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Unroll
  */
 @CompileDynamic
 class ProtobufKotlinDslPluginTest extends Specification {
-  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.1.1", "6.5", "7.4.2"]
+  private static final List<String> GRADLE_VERSIONS = ["5.6", "6.1.1", "6.5.1", "7.4.2"]
   private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.0.0", "4.1.0", "7.2.1"]
 
   @Unroll


### PR DESCRIPTION
This allows using the task configuration avoidance APIs and makes the
dependency graph much clearer.

Gradle 6.5 suffered from https://github.com/gradle/gradle/issues/13367.

(I'm aware this will conflict with the Eclipse PR, but resolving the conflict won't be hard.)

When reviewing, I suggest ignoring whitespace.