### PR TITLE
Remove dependency on Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ configurations {
 dependencies {
   compileOnly "com.android.tools.build:gradle:4.1.0"
 
-  implementation 'com.google.guava:guava:27.0.1-jre'
   implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
 
   testImplementation 'junit:junit:4.12'

--- a/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
@@ -28,7 +28,6 @@
  */
 package com.google.protobuf.gradle
 
-import com.google.common.base.Preconditions
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import org.gradle.api.Named

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -31,8 +31,6 @@ package com.google.protobuf.gradle
 
 import static java.nio.charset.StandardCharsets.US_ASCII
 
-import com.google.common.base.Preconditions
-import com.google.common.collect.ImmutableList
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.transform.TypeChecked
@@ -103,7 +101,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   transient private SourceSet sourceSet
   @SuppressWarnings("UnnecessaryTransientModifier") // It is not necessary for task to implement Serializable
   transient private Object variant
-  private ImmutableList<String> flavors
+  private List<String> flavors
   private String buildType
   private boolean isTestVariant
   private final Provider<Boolean> isAndroidProject = providerFactory.provider { Utils.isAndroidProject(project) }
@@ -275,11 +273,11 @@ public abstract class GenerateProtoTask extends DefaultTask {
     this.isTestVariant = isTestVariant
   }
 
-  void setFlavors(ImmutableList<String> flavors) {
+  void setFlavors(List<String> flavors) {
     checkInitializing()
     Preconditions.checkState(isAndroidProject.get(),
         'flavors should not be set in a Java project')
-    this.flavors = flavors
+    this.flavors = Collections.unmodifiableList(new ArrayList<String>(flavors))
   }
 
   void setBuildType(String buildType) {
@@ -370,7 +368,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   }
 
   @Internal("Not an actual input to the task, only used to find tasks belonging to a variant")
-  ImmutableList<String> getFlavors() {
+  List<String> getFlavors() {
     Preconditions.checkState(isAndroidProject.get(),
         'flavors should not be used in a Java project')
     Preconditions.checkNotNull(flavors, 'flavors is not set')

--- a/src/main/groovy/com/google/protobuf/gradle/Preconditions.java
+++ b/src/main/groovy/com/google/protobuf/gradle/Preconditions.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.protobuf.gradle;
+
+/**
+ * Common assertions helper.
+ */
+final class Preconditions {
+  private Preconditions() {} // prevent instantiation
+
+  public static void checkState(boolean expectedState) {
+    if (!expectedState) {
+      throw new IllegalStateException();
+    }
+  }
+
+  public static void checkState(boolean expectedState, Object errorMessage) {
+    if (!expectedState) {
+      throw new IllegalStateException(String.valueOf(errorMessage));
+    }
+  }
+
+  public static <T> T checkNotNull(T obj, Object errorMessage) {
+    if (obj == null) {
+      throw new NullPointerException(String.valueOf(errorMessage));
+    }
+    return obj;
+  }
+}

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -29,7 +29,6 @@
  */
 package com.google.protobuf.gradle
 
-import com.google.common.collect.ImmutableList
 import groovy.transform.CompileStatic
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
@@ -320,7 +319,7 @@ class ProtobufPlugin implements Plugin<Project> {
       Provider<GenerateProtoTask> generateProtoTask = addGenerateProtoTask(
           variant.name, sourceDirs, extractProtosDirs, extractIncludeProtosTask) {
         it.setVariant(variant, isTestVariant)
-        it.flavors = ImmutableList.copyOf(variant.productFlavors.collect { it.name } )
+        it.flavors = variant.productFlavors.collect { it.name }
         if (variant.hasProperty('buildType')) {
           it.buildType = variant.buildType.name
         }

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -28,7 +28,6 @@
  */
 package com.google.protobuf.gradle
 
-import com.google.common.base.Preconditions
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet

--- a/src/test/groovy/com/google/protobuf/gradle/IDESupportTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/IDESupportTest.groovy
@@ -28,7 +28,6 @@
  */
 package com.google.protobuf.gradle
 
-import com.google.common.collect.ImmutableSet
 import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -80,25 +79,25 @@ class IDESupportTest extends Specification {
       }
     }
 
-    Set<String> expectedSourceDir = ImmutableSet.builder()
-      .add('file://$MODULE_DIR$/src/main/java')
-      .add('file://$MODULE_DIR$/src/grpc/proto')
-      .add('file://$MODULE_DIR$/src/main/proto')
-      .add('file://$MODULE_DIR$/build/extracted-include-protos/grpc')
-      .add('file://$MODULE_DIR$/build/extracted-protos/main')
-      .add('file://$MODULE_DIR$/build/extracted-include-protos/main')
-      .add('file://$MODULE_DIR$/build/extracted-protos/grpc')
-      .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/java')
-      .add('file://$MODULE_DIR$/build/generated/source/proto/grpc/grpc_output')
-      .add('file://$MODULE_DIR$/build/generated/source/proto/main/java')
-      .build()
-    Set<String> expectedTestSourceDir = ImmutableSet.builder()
-      .add('file://$MODULE_DIR$/src/test/java')
-      .add('file://$MODULE_DIR$/src/test/proto')
-      .add('file://$MODULE_DIR$/build/extracted-protos/test')
-      .add('file://$MODULE_DIR$/build/extracted-include-protos/test')
-      .add('file://$MODULE_DIR$/build/generated/source/proto/test/java')
-      .build()
+    Set<String> expectedSourceDir = [
+      'file://$MODULE_DIR$/src/main/java',
+      'file://$MODULE_DIR$/src/grpc/proto',
+      'file://$MODULE_DIR$/src/main/proto',
+      'file://$MODULE_DIR$/build/extracted-include-protos/grpc',
+      'file://$MODULE_DIR$/build/extracted-protos/main',
+      'file://$MODULE_DIR$/build/extracted-include-protos/main',
+      'file://$MODULE_DIR$/build/extracted-protos/grpc',
+      'file://$MODULE_DIR$/build/generated/source/proto/grpc/java',
+      'file://$MODULE_DIR$/build/generated/source/proto/grpc/grpc_output',
+      'file://$MODULE_DIR$/build/generated/source/proto/main/java',
+    ]
+    Set<String> expectedTestSourceDir = [
+      'file://$MODULE_DIR$/src/test/java',
+      'file://$MODULE_DIR$/src/test/proto',
+      'file://$MODULE_DIR$/build/extracted-protos/test',
+      'file://$MODULE_DIR$/build/extracted-include-protos/test',
+      'file://$MODULE_DIR$/build/generated/source/proto/test/java',
+    ]
     Set<String> expectedGeneratedDirs = [
       'file://$MODULE_DIR$/build/extracted-include-protos/grpc',
       'file://$MODULE_DIR$/build/extracted-protos/main',
@@ -154,14 +153,14 @@ class IDESupportTest extends Specification {
       }
     }
 
-    Set<String> expectedSourceDir = ImmutableSet.builder()
-      .add('src/main/java')
-      .add('src/test/java')
-      .add('build/generated/source/proto/grpc/java')
-      .add('build/generated/source/proto/grpc/grpc_output')
-      .add('build/generated/source/proto/main/java')
-      .add('build/generated/source/proto/test/java')
-      .build()
+    Set<String> expectedSourceDir = [
+      'src/main/java',
+      'src/test/java',
+      'build/generated/source/proto/grpc/java',
+      'build/generated/source/proto/grpc/grpc_output',
+      'build/generated/source/proto/main/java',
+      'build/generated/source/proto/test/java',
+    ]
     assert Objects.equals(expectedSourceDir, sourceDir)
 
     where:


### PR DESCRIPTION
We like Guava, but the plugin has little need for it. As a side-benefit dropping it avoids systems-not-handling-classpaths-correctly issues like #247. We wouldn't drop Guava just for that reason (as the ecosystem should fix its bugs), but instead of just removing it from the API surface, let's remove it entirely. Similarly, we could continue using it in our tests, but we really don't need it.

Fixes #572