### PR TITLE
Upgrade osdetector-gradle-plugin to 1.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   compileOnly "com.android.tools.build:gradle:4.1.0"
 
   implementation 'com.google.guava:guava:27.0.1-jre'
-  implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
+  implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.1'
 
   testImplementation 'junit:junit:4.12'
   testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') {


### PR DESCRIPTION
This avoids the usage of VersionNumber which will begin triggering warnings in Gradle.

CC @YifeiZhuang 