### PR TITLE
Change PluginClasspath for tests to binary plugin from maven local

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,16 @@ if (!gradle.startParameter.taskNames.intersect(['publishPlugins'])) {
   }
 }
 
+gradlePlugin {
+  plugins {
+    protobufPlugin {
+      id = "com.google.protobuf"
+      implementationClass = "com.google.protobuf.gradle.ProtobufPlugin"
+      description = "The Protobuf plugin provides protobuf compilation to your project."
+    }
+  }
+}
+
 pluginBundle {
   website = 'https://github.com/google/protobuf-gradle-plugin'
   vcsUrl = 'https://github.com/google/protobuf-gradle-plugin'
@@ -185,8 +195,23 @@ tasks.named('compileKotlin') {
     compileKotlin.classpath += files(compileGroovy.destinationDirectory)
 }
 
-test {
+tasks.named('test') {
   testLogging {
     events = ["standard_out", "standard_error", "started", "passed", "failed", "skipped"]
   }
+
+  // Hack for gradle runner test classloader.
+  //
+  // GradleRunner.withPluginClasspath method loads a plugin under test to the classloader_1.
+  // When the test project is executed, it will load plugins to a project classloader_2.
+  // The classloader_1 doesn't known about classloader_2. When the plugin under test will use classes which
+  // was loaded to project with the classloader_2, ClassNotFoundException will be thrown.
+  //
+  // To fix this problem, don't use the withPluginClasspath method.
+  // Provide a plugin under test with the maven local repository.
+  systemProperty("protobufPluginVersion", version)
+  dependsOn(
+    "publishProtobufPluginPluginMarkerMavenPublicationToMavenLocal",
+    "publishPluginMavenPublicationToMavenLocal"
+  )
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,8 @@ tasks.withType(GenerateModuleMetadata) {
   enabled = false
 }
 
+File testRepoUrl = layout.buildDirectory.dir('testRepo').get().asFile
+
 publishing {
   publications {
     pluginMaven(MavenPublication) {
@@ -131,6 +133,10 @@ publishing {
   }
 
   repositories {
+    maven {
+      url = testRepoUrl
+      name = "test"
+    }
     maven {
       String releaseUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
       String snapshotUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
@@ -210,8 +216,9 @@ tasks.named('test') {
   // To fix this problem, don't use the withPluginClasspath method.
   // Provide a plugin under test with the maven local repository.
   systemProperty("protobufPluginVersion", version)
+  systemProperty("testRepoUrl", testRepoUrl.absolutePath)
   dependsOn(
-    "publishProtobufPluginPluginMarkerMavenPublicationToMavenLocal",
-    "publishPluginMavenPublicationToMavenLocal"
+    "publishProtobufPluginPluginMarkerMavenPublicationToTestRepository",
+    "publishPluginMavenPublicationToTestRepository"
   )
 }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -40,6 +40,8 @@ import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.LibraryElements
@@ -112,6 +114,11 @@ class ProtobufPlugin implements Plugin<Project> {
                 + ' The Java plugin or one of the Android plugins must be applied to the project first.')
           }
         }
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    private static void linkGenerateProtoTasksToTask(Task task, SourceDirectorySet srcDirSet) {
+      task.source(srcDirSet)
     }
 
     @TypeChecked(TypeCheckingMode.SKIP) // Don't depend on AGP
@@ -340,12 +347,9 @@ class ProtobufPlugin implements Plugin<Project> {
         // This cannot be called once task execution has started.
         variant.registerJavaGeneratingTask(
             generateProtoTask.get(), generateProtoTask.get().getOutputSourceDirectories())
-        project.plugins.withId("org.jetbrains.kotlin.android") {
-          String kotlinTaskName = Utils.getKotlinAndroidCompileTaskName(project, variant.name)
-          project.tasks.named(kotlinTaskName).configure { task ->
-            task.source(sourceDirectorySetForGenerateProtoTask(variant.name, generateProtoTask))
-          }
-        }
+        linkGenerateProtoTasksToTaskName(
+            Utils.getKotlinAndroidCompileTaskName(project, variant.name),
+            sourceDirectorySetForGenerateProtoTask(variant.name, generateProtoTask))
       }
     }
 
@@ -442,6 +446,22 @@ class ProtobufPlugin implements Plugin<Project> {
         // 'compile' and it cannot get the proto files from 'main' sourceSet through the
         // configuration.
         it.inputFiles.from(testedCompileClasspathConfiguration)
+      }
+    }
+
+    private void linkGenerateProtoTasksToTaskName(String compileTaskName, SourceDirectorySet srcDirSet) {
+      try {
+        project.tasks.named(compileTaskName).configure { compileTask ->
+          linkGenerateProtoTasksToTask(compileTask, srcDirSet)
+        }
+      } catch (UnknownDomainObjectException ignore) {
+        // It is possible for a compile task to not exist yet. For example, if someone applied
+        // the proto plugin and then later applies the kotlin plugin.
+        project.tasks.configureEach { Task task ->
+          if (task.name == compileTaskName) {
+            linkGenerateProtoTasksToTask(task, srcDirSet)
+          }
+        }
       }
     }
 

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -29,6 +29,10 @@
  */
 package com.google.protobuf.gradle
 
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.TestVariant
+import com.android.build.gradle.api.UnitTestVariant
+import com.google.protobuf.gradle.internal.ProjectExt
 import groovy.transform.CompileStatic
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
@@ -124,14 +128,12 @@ class ProtobufPlugin implements Plugin<Project> {
             Configuration protobufConfig = createProtobufConfiguration(sourceSet.name)
             setupExtractProtosTask(sourceSet.name, protobufConfig)
           }
-          getNonTestVariants().configureEach { variant ->
-            addTasksForVariant(variant, false, postConfigure)
-          }
-          project.android.unitTestVariants.configureEach { variant ->
-            addTasksForVariant(variant, true, postConfigure)
-          }
-          project.android.testVariants.configureEach { variant ->
-            addTasksForVariant(variant, true, postConfigure)
+          ProjectExt.forEachVariant(this.project) { BaseVariant variant ->
+            addTasksForVariant(
+              variant,
+              variant instanceof TestVariant || variant instanceof UnitTestVariant,
+              postConfigure
+            )
           }
         } else {
           project.sourceSets.configureEach { sourceSet ->
@@ -218,12 +220,6 @@ class ProtobufPlugin implements Plugin<Project> {
       sds.srcDir("src/${name}/proto")
       sds.include("**/*.proto")
       return sds
-    }
-
-    @TypeChecked(TypeCheckingMode.SKIP) // Don't depend on AGP
-    private Object getNonTestVariants() {
-      return project.android.hasProperty('libraryVariants') ?
-          project.android.libraryVariants : project.android.applicationVariants
     }
 
     /**

--- a/src/main/groovy/com/google/protobuf/gradle/internal/ProjectExt.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/internal/ProjectExt.groovy
@@ -33,11 +33,7 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestExtension
 import com.android.build.gradle.TestedExtension
-import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.api.LibraryVariant
-import com.android.build.gradle.api.TestVariant
-import com.android.build.gradle.api.UnitTestVariant
 import groovy.transform.CompileStatic
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -48,25 +44,25 @@ class ProjectExt {
   }
 
   @SuppressWarnings(["CouldBeSwitchStatement"]) // `if` is better than fallthrough `switch`
-  static void forEachVariant(final Project project, final Action<BaseVariant> action) {
+  static void forEachVariant(final Project project, final Action<? extends BaseVariant> action) {
     BaseExtension android = project.extensions.getByName("android") as BaseExtension
     project.logger.debug("$project has '$android'")
 
     if (android instanceof AppExtension) {
-      (android as AppExtension).getApplicationVariants().all(action as Action<ApplicationVariant>)
+      android.getApplicationVariants().all(action)
     }
 
     if (android instanceof LibraryExtension) {
-      (android as LibraryExtension).getLibraryVariants().all(action as Action<LibraryVariant>)
+      android.getLibraryVariants().all(action)
     }
 
     if (android instanceof TestExtension) {
-      (android as TestExtension).getApplicationVariants().all(action as Action<ApplicationVariant>)
+      android.getApplicationVariants().all(action)
     }
 
     if (android instanceof TestedExtension) {
-      (android as TestedExtension).getTestVariants().all(action as Action<TestVariant>)
-      (android as TestedExtension).getUnitTestVariants().all(action as Action<UnitTestVariant>)
+      android.getTestVariants().all(action)
+      android.getUnitTestVariants().all(action)
     }
   }
 }

--- a/src/main/groovy/com/google/protobuf/gradle/internal/ProjectExt.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/internal/ProjectExt.groovy
@@ -49,20 +49,20 @@ class ProjectExt {
     project.logger.debug("$project has '$android'")
 
     if (android instanceof AppExtension) {
-      android.getApplicationVariants().all(action)
+      (android as AppExtension).getApplicationVariants().all(action)
     }
 
     if (android instanceof LibraryExtension) {
-      android.getLibraryVariants().all(action)
+      (android as LibraryExtension).getLibraryVariants().all(action)
     }
 
     if (android instanceof TestExtension) {
-      android.getApplicationVariants().all(action)
+      (android as TestExtension).getApplicationVariants().all(action)
     }
 
     if (android instanceof TestedExtension) {
-      android.getTestVariants().all(action)
-      android.getUnitTestVariants().all(action)
+      (android as TestedExtension).getTestVariants().all(action)
+      (android as TestedExtension).getUnitTestVariants().all(action)
     }
   }
 }

--- a/src/main/groovy/com/google/protobuf/gradle/internal/ProjectExt.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/internal/ProjectExt.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.protobuf.gradle.internal
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
+import com.android.build.gradle.TestedExtension
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.LibraryVariant
+import com.android.build.gradle.api.TestVariant
+import com.android.build.gradle.api.UnitTestVariant
+import groovy.transform.CompileStatic
+import org.gradle.api.Action
+import org.gradle.api.Project
+
+@CompileStatic
+class ProjectExt {
+  private ProjectExt() {
+  }
+
+  @SuppressWarnings(["CouldBeSwitchStatement"]) // `if` is better than fallthrough `switch`
+  static void forEachVariant(final Project project, final Action<BaseVariant> action) {
+    BaseExtension android = project.extensions.getByName("android") as BaseExtension
+    project.logger.debug("$project has '$android'")
+
+    if (android instanceof AppExtension) {
+      (android as AppExtension).getApplicationVariants().all(action as Action<ApplicationVariant>)
+    }
+
+    if (android instanceof LibraryExtension) {
+      (android as LibraryExtension).getLibraryVariants().all(action as Action<LibraryVariant>)
+    }
+
+    if (android instanceof TestExtension) {
+      (android as TestExtension).getApplicationVariants().all(action as Action<ApplicationVariant>)
+    }
+
+    if (android instanceof TestedExtension) {
+      (android as TestedExtension).getTestVariants().all(action as Action<TestVariant>)
+      (android as TestedExtension).getUnitTestVariants().all(action as Action<UnitTestVariant>)
+    }
+  }
+}

--- a/src/main/resources/META-INF/gradle-plugins/com.google.protobuf.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.google.protobuf.properties
@@ -1,1 +1,0 @@
-implementation-class=com.google.protobuf.gradle.ProtobufPlugin

--- a/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/AndroidProjectDetectionTest.groovy
@@ -1,7 +1,5 @@
 package com.google.protobuf.gradle
 
-import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
-
 import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
@@ -38,12 +36,12 @@ class AndroidProjectDetectionTest extends Specification {
     appendUtilIsAndroidProjectCheckTask(new File(mainProjectDir, "build.gradle"), true)
 
     when: "checkForAndroidPlugin task evaluates Utils.isAndroidProject"
-    BuildResult result = buildAndroidProject(
+    BuildResult result = ProtobufPluginTestHelper.getAndroidGradleRunner(
         mainProjectDir,
         gradleVersion,
         agpVersion,
         "checkForAndroidPlugin"
-    )
+    ).build()
 
     then: "Utils.isAndroidProject evaluation matched assertion in task checkForAndroidPlugin"
     assert result.task(":checkForAndroidPlugin").outcome == TaskOutcome.SUCCESS
@@ -63,6 +61,7 @@ class AndroidProjectDetectionTest extends Specification {
        .copyDirs('testProjectLite')
        .build()
     appendUtilIsAndroidProjectCheckTask(new File(subProjectStaging, "build.gradle"), false)
+
     File mainProjectDir = ProtobufPluginTestHelper.projectBuilder("rootModuleAndroidProject")
        .copyDirs('testProjectAndroid', 'testProjectAndroidBare')
        .copySubProjects(subProjectStaging)
@@ -71,12 +70,12 @@ class AndroidProjectDetectionTest extends Specification {
     appendUtilIsAndroidProjectCheckTask(new File(mainProjectDir, "build.gradle"), true)
 
     when: "checkForAndroidPlugin task evaluates Utils.isAndroidProject"
-    BuildResult result = buildAndroidProject(
+    BuildResult result = ProtobufPluginTestHelper.getAndroidGradleRunner(
        mainProjectDir,
        gradleVersion,
        agpVersion,
        "checkForAndroidPlugin"
-    )
+    ).build()
 
     then: "Utils.isAndroidProject evaluation matched assertion in task checkForAndroidPlugin"
     assert result.task(":checkForAndroidPlugin").outcome == TaskOutcome.SUCCESS

--- a/src/test/groovy/com/google/protobuf/gradle/IDESupportTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/IDESupportTest.groovy
@@ -46,7 +46,7 @@ class IDESupportTest extends Specification {
   @Unroll
   void "testProject proto and generated output directories should be added to intellij [gradle #gradleVersion]"() {
     given: "project from testProject"
-    File projectDir = ProtobufPluginTestHelper.projectBuilder('testIdea')
+    File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
       .copyDirs('testProjectBase', 'testProject')
       .build()
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
@@ -1,7 +1,5 @@
 package com.google.protobuf.gradle
 
-import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
-
 import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
@@ -36,12 +34,12 @@ class ProtobufAndroidPluginKotlinTest extends Specification {
             .withKotlin(kotlinVersion)
             .build()
     when: "build is invoked"
-    BuildResult result = buildAndroidProject(
+    BuildResult result = ProtobufPluginTestHelper.getAndroidGradleRunner(
         mainProjectDir,
         gradleVersion,
         agpVersion,
         "testProjectAndroid:build"
-    )
+    ).build()
 
     then: "it succeed"
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginTest.groovy
@@ -1,8 +1,5 @@
 package com.google.protobuf.gradle
 
-import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
-import static com.google.protobuf.gradle.ProtobufPluginTestHelper.getAndroidGradleRunner
-
 import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -35,12 +32,12 @@ class ProtobufAndroidPluginTest extends Specification {
         .withAndroidPlugin(agpVersion)
         .build()
     when: "build is invoked"
-    BuildResult result = buildAndroidProject(
+    BuildResult result = ProtobufPluginTestHelper.getAndroidGradleRunner(
         mainProjectDir,
         gradleVersion,
         agpVersion,
         "testProjectAndroid:build"
-    )
+    ).build()
 
     then: "it succeed"
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
@@ -67,7 +64,7 @@ class ProtobufAndroidPluginTest extends Specification {
             .withAndroidPlugin(agpVersion)
             .build()
     and:
-    GradleRunner runner = getAndroidGradleRunner(
+    GradleRunner runner = ProtobufPluginTestHelper.getAndroidGradleRunner(
             mainProjectDir,
             gradleVersion,
             agpVersion,
@@ -93,13 +90,13 @@ class ProtobufAndroidPluginTest extends Specification {
     result.task(":testProjectAndroid:assembleDebug").outcome == TaskOutcome.UP_TO_DATE
 
     when: "clean is invoked, before a build"
-    buildAndroidProject(
+    ProtobufPluginTestHelper.getAndroidGradleRunner(
             mainProjectDir,
             gradleVersion,
             agpVersion,
             "testProjectAndroid:clean",
             "-Dorg.gradle.unsafe.configuration-cache=true"
-    )
+    ).build()
     result = runner.build()
 
     then: "it succeed"
@@ -127,12 +124,12 @@ class ProtobufAndroidPluginTest extends Specification {
             .withAndroidPlugin(agpVersion)
             .build()
     when: "build is invoked"
-    BuildResult result = buildAndroidProject(
+    BuildResult result = ProtobufPluginTestHelper.getAndroidGradleRunner(
             mainProjectDir,
             gradleVersion,
             agpVersion,
             "testProjectAndroid:build"
-    )
+    ).build()
 
     then: "it succeed"
     result.task(":testProjectAndroid:build").outcome == TaskOutcome.SUCCESS
@@ -159,12 +156,12 @@ class ProtobufAndroidPluginTest extends Specification {
             .withAndroidPlugin(agpVersion)
             .build()
     when: "build is invoked"
-    BuildResult result = buildAndroidProject(
+    BuildResult result = ProtobufPluginTestHelper.getAndroidGradleRunner(
             mainProjectDir,
             gradleVersion,
             agpVersion,
             "testProjectAndroid:assembleAndroidTest"
-    )
+    ).build()
 
     then: "it succeed"
     result.task(":testProjectAndroid:assembleAndroidTest").outcome == TaskOutcome.SUCCESS

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -60,15 +60,11 @@ class ProtobufJavaPluginTest extends Specification {
         .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-      .withProjectDir(projectDir)
-      .withArguments('build', '--stacktrace')
-      .withPluginClasspath()
-      .withGradleVersion(gradleVersion)
-      .forwardStdOutput(new OutputStreamWriter(System.out))
-      .forwardStdError(new OutputStreamWriter(System.err))
-      .withDebug(true)
-      .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -88,16 +84,12 @@ class ProtobufJavaPluginTest extends Specification {
     new File(projectDir, "gradle.properties").write('org.gradle.unsafe.configuration-cache.max-problems=42')
 
     and:
-    GradleRunner runner = GradleRunner.create()
-      .withProjectDir(projectDir)
-      .withArguments(
-          'build', '--stacktrace',
-          '--configuration-cache'
-      )
-      .withPluginClasspath()
-      .withGradleVersion(gradleVersion)
-      .forwardStdOutput(new OutputStreamWriter(System.out))
-      .forwardStdError(new OutputStreamWriter(System.err))
+    GradleRunner runner = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build",
+      "--configuration-cache"
+    )
 
     when: "build is invoked"
     BuildResult result = runner.build()
@@ -131,15 +123,11 @@ class ProtobufJavaPluginTest extends Specification {
             .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -157,13 +145,11 @@ class ProtobufJavaPluginTest extends Specification {
         .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-      .withProjectDir(projectDir)
-      .withArguments('build', '--stacktrace')
-      .withPluginClasspath()
-      .withDebug(true)
-      .withGradleVersion(gradleVersion)
-      .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -182,13 +168,11 @@ class ProtobufJavaPluginTest extends Specification {
         .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-      .withProjectDir(projectDir)
-      .withArguments('build')
-      .withPluginClasspath()
-      .withDebug(true)
-      .withGradleVersion(gradleVersion)
-      .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -206,15 +190,11 @@ class ProtobufJavaPluginTest extends Specification {
         .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-      .withProjectDir(projectDir)
-      .withArguments('build', '--stacktrace')
-      .withPluginClasspath()
-      .withGradleVersion(gradleVersion)
-      .forwardStdOutput(new OutputStreamWriter(System.out))
-      .forwardStdError(new OutputStreamWriter(System.err))
-      .withDebug(true)
-      .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -238,15 +218,11 @@ class ProtobufJavaPluginTest extends Specification {
         .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-      .withProjectDir(mainProjectDir)
-      .withArguments('testProjectDependent:build', '--stacktrace')
-      .withPluginClasspath()
-      .withGradleVersion(gradleVersion)
-      .forwardStdOutput(new OutputStreamWriter(System.out))
-      .forwardStdError(new OutputStreamWriter(System.err))
-      .withDebug(true)
-      .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      mainProjectDir,
+      gradleVersion,
+      "testProjectDependent:build"
+    ).build()
 
     then: "it succeed"
     result.task(":testProjectDependent:build").outcome == TaskOutcome.SUCCESS
@@ -263,15 +239,11 @@ class ProtobufJavaPluginTest extends Specification {
             .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -296,15 +268,11 @@ class ProtobufJavaPluginTest extends Specification {
             .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-            .withProjectDir(mainProjectDir)
-            .withArguments('testProjectDependentApp:build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      mainProjectDir,
+      gradleVersion,
+      "testProjectDependentApp:build"
+    ).build()
 
     then: "it succeed"
     result.task(":testProjectDependentApp:build").outcome == TaskOutcome.SUCCESS
@@ -321,15 +289,11 @@ class ProtobufJavaPluginTest extends Specification {
         .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-      .withProjectDir(projectDir)
-      .withArguments('build', '--stacktrace')
-      .withPluginClasspath()
-      .withGradleVersion(gradleVersion)
-      .forwardStdOutput(new OutputStreamWriter(System.out))
-      .forwardStdError(new OutputStreamWriter(System.err))
-      .withDebug(true)
-      .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -346,15 +310,11 @@ class ProtobufJavaPluginTest extends Specification {
             .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeeds"
     result.task(":build").outcome == TaskOutcome.SUCCESS
@@ -367,15 +327,11 @@ class ProtobufJavaPluginTest extends Specification {
                   artifact = 'com.google.protobuf:protoc:3.0.2'
                 }
               }""")
-    result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "generateProto is not UP_TO_DATE"
     result.task(":generateProto").outcome == TaskOutcome.SUCCESS
@@ -390,15 +346,11 @@ class ProtobufJavaPluginTest extends Specification {
                   }
                 }
               }""")
-    result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "generateProto is not UP_TO_DATE"
     result.task(":generateGrpcProto").outcome == TaskOutcome.SUCCESS
@@ -430,15 +382,11 @@ class ProtobufJavaPluginTest extends Specification {
             path = "\$configurations.protoc.singleFile"
           }
         }""")
-    BuildResult result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeeds"
     result.task(":generateProto").outcome == TaskOutcome.SUCCESS
@@ -446,15 +394,11 @@ class ProtobufJavaPluginTest extends Specification {
     when: "protoc path is changed and build runs again"
     buildGradleFile.text = buildGradleFile.text.replace("com.google.protobuf:protoc:3.0.0",
         "com.google.protobuf:protoc:3.0.2")
-    result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "generateProto is not UP_TO_DATE"
     result.task(":generateProto").outcome == TaskOutcome.SUCCESS
@@ -471,30 +415,22 @@ class ProtobufJavaPluginTest extends Specification {
             .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "it succeed"
     result.task(":build").outcome == TaskOutcome.SUCCESS
 
     when: "Java class is added and build runs again"
     new File(projectDir, "src/main/java/Bar.java").write("public class Bar {}")
-    result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "extract include test protos is up to date because it ignores classpath changes"
     result.task(":extractIncludeTestProto").outcome == TaskOutcome.UP_TO_DATE
@@ -503,15 +439,11 @@ class ProtobufJavaPluginTest extends Specification {
     new File(projectDir, "empty_proto.proto").write("syntax = \"proto3\";")
     new File(projectDir, "build.gradle")
             .append("\n dependencies { implementation files ('empty_proto.proto') } ")
-    result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .withDebug(true)
-            .build()
+    result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "build"
+    ).build()
 
     then: "extract include protos is not up to date"
     result.task(":extractIncludeProto").outcome == TaskOutcome.SUCCESS

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslCopySpecTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslCopySpecTest.groovy
@@ -2,7 +2,6 @@ package com.google.protobuf.gradle
 
 import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -22,14 +21,12 @@ class ProtobufKotlinDslCopySpecTest extends Specification {
             .build()
 
     when: "build is invoked"
-    BuildResult result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments('test', 'build', '--stacktrace')
-            .withPluginClasspath()
-            .withGradleVersion(gradleVersion)
-            .forwardStdOutput(new OutputStreamWriter(System.out))
-            .forwardStdError(new OutputStreamWriter(System.err))
-            .build()
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "test",
+      "build"
+    ).build()
 
     then: "it succeed"
 

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufKotlinDslPluginTest.groovy
@@ -1,7 +1,5 @@
 package com.google.protobuf.gradle
 
-import static com.google.protobuf.gradle.ProtobufPluginTestHelper.buildAndroidProject
-
 import groovy.transform.CompileDynamic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
@@ -60,12 +58,12 @@ class ProtobufKotlinDslPluginTest extends Specification {
             .build()
 
     when: "build is invoked"
-    BuildResult result = buildAndroidProject(
+    BuildResult result = ProtobufPluginTestHelper.getAndroidGradleRunner(
         mainProjectDir,
         gradleVersion,
         agpVersion,
         "testProjectAndroidKotlinDsl:build"
-    )
+    ).build()
 
     then: "it succeed"
     result.task(":testProjectAndroidKotlinDsl:build").outcome == TaskOutcome.SUCCESS

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -129,7 +129,9 @@ final class ProtobufPluginTestHelper {
       settingsFile << """
       |pluginManagement {
       |  repositories {
-      |    mavenLocal()
+      |    maven {
+      |      url "${System.getProperty("testRepoUrl", "unknown")}"
+      |    }
       |    google()
       |    gradlePluginPortal()
       |  }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -34,17 +34,9 @@ final class ProtobufPluginTestHelper {
     List<String> args = arguments.toList()
     args.add("--stacktrace")
 
-    return getGradleRunner(projectDir, gradleVersion, args)
-  }
-
-  static GradleRunner getGradleRunner(
-    File projectDir,
-    String gradleVersion,
-    List<String> arguments
-  ) {
     return GradleRunner.create()
       .withProjectDir(projectDir)
-      .withArguments(arguments)
+      .withArguments(args)
       .withGradleVersion(gradleVersion)
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
@@ -76,7 +68,13 @@ final class ProtobufPluginTestHelper {
     //
     // Set memory limit for all gradle build, not only for dexing
     args.add("-Dorg.gradle.jvmargs=-Xmx1g")
-    return getGradleRunner(projectDir, gradleVersion, args)
+
+    return GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments(args)
+      .withGradleVersion(gradleVersion)
+      .forwardStdOutput(new OutputStreamWriter(System.out))
+      .forwardStdError(new OutputStreamWriter(System.err))
   }
 
   /**

--- a/testProject/settings.gradle
+++ b/testProject/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProject'

--- a/testProjectAndroid/settings.gradle
+++ b/testProjectAndroid/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectAndroid'

--- a/testProjectAndroidKotlinDsl/settings.gradle.kts
+++ b/testProjectAndroidKotlinDsl/settings.gradle.kts
@@ -1,2 +1,0 @@
-rootProject.name = "testProjectAndroidKotlinDsl"
-rootProject.buildFileName = "build.gradle.kts"

--- a/testProjectAndroidLibrary/settings.gradle
+++ b/testProjectAndroidLibrary/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectAndroidLibrary'

--- a/testProjectBuildTimeProto/settings.gradle
+++ b/testProjectBuildTimeProto/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectBuildTimeProto'

--- a/testProjectCustomProtoDir/settings.gradle
+++ b/testProjectCustomProtoDir/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectCustomProtoDir'

--- a/testProjectDependent/settings.gradle
+++ b/testProjectDependent/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectDependent'

--- a/testProjectDependentApp/settings.gradle
+++ b/testProjectDependentApp/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectDependentApp'

--- a/testProjectJavaAndKotlin/settings.gradle
+++ b/testProjectJavaAndKotlin/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectJavaAndKotlin'

--- a/testProjectJavaLibrary/settings.gradle
+++ b/testProjectJavaLibrary/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectJavaLibrary'

--- a/testProjectKotlin/settings.gradle
+++ b/testProjectKotlin/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectKotlin'

--- a/testProjectKotlinDslBase/settings.gradle.kts
+++ b/testProjectKotlinDslBase/settings.gradle.kts
@@ -1,3 +1,0 @@
-rootProject.name = "exampleProject"
-rootProject.buildFileName = "build.gradle.kts"
-

--- a/testProjectKotlinDslCopySpec/settings.gradle.kts
+++ b/testProjectKotlinDslCopySpec/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name="testProjectKotlinDslCopySpec"

--- a/testProjectLite/settings.gradle
+++ b/testProjectLite/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'testProjectLite'


### PR DESCRIPTION
**Background**
Plugin can't works in test with classes that were loaded by gradle project.

For example:
Our plugin works with classes from agp. Agp is not bundled into plugin.
Plugin checks is agp was applied, but for some reasons `ClassNotFoundException` will be thrown. `BaseExtension` not found.
```groovy
withPlugin("android") {
  // if we are here it means gradle has successfully loaded agp plugin
  project.android as BaseExtension
}
```

**Changes**
Remove `withPluginClasspath` from tests. Provide the plugin under test via maven local. Before the test run, gradle will publish the plugin to maven local.

**Test plan**
Green pipelines.

**Source of the problem**
`withPluginClasspath` loads the plugin under test to `classloader_1`. Gradle loads applied plugins to `classpath_2`. `classpath_1` is the parent to `classpath_2`. The parent classpath cannot work with classes loaded by child classpaths.

**References** 
https://github.com/gradle/gradle/issues/11338
https://discuss.gradle.org/t/testkit-somehow-excludes-compileonly-dependencies/19842/5
