### PR TITLE
Don't use deprecated IdeaModule.sourceDirs property when configuring newer Gradle versions

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -33,12 +33,15 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet
 import org.gradle.plugins.ide.idea.GenerateIdeaModule
 import org.gradle.plugins.ide.idea.model.IdeaModel
+import org.gradle.util.GradleVersion
 
 /**
  * Utility classes.
  */
 @CompileStatic
 class Utils {
+  private static GradleVersion GRADLE_7_4 = GradleVersion.version("7.4")
+
   /**
    * Returns the conventional name of a configuration for a sourceSet
    */
@@ -108,7 +111,11 @@ class Utils {
     project.plugins.withId("idea") {
       IdeaModel model = project.getExtensions().findByType(IdeaModel)
       if (isTest) {
-        model.module.testSourceDirs += f
+        if (GradleVersion.current() >= GRADLE_7_4) {
+          model.module.invokeMethod("getTestSources", null).invokeMethod("from", f) // TODO call directly after updating Gradle wrapper to 7.4+
+        } else {
+          model.module.testSourceDirs += f
+        }
       } else {
         model.module.sourceDirs += f
       }

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -30,6 +30,7 @@ package com.google.protobuf.gradle
 
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.SourceSet
 import org.gradle.plugins.ide.idea.GenerateIdeaModule
 import org.gradle.plugins.ide.idea.model.IdeaModel
@@ -112,7 +113,8 @@ class Utils {
       IdeaModel model = project.getExtensions().findByType(IdeaModel)
       if (isTest) {
         if (GradleVersion.current() >= GRADLE_7_4) {
-          model.module.invokeMethod("getTestSources", null).invokeMethod("from", f) // TODO call directly after updating Gradle wrapper to 7.4+
+          // TODO call directly after updating Gradle wrapper to 7.4+
+          ((ConfigurableFileCollection) model.module.invokeMethod("getTestSources", null)).from(f)
         } else {
           model.module.testSourceDirs += f
         }

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -41,7 +41,7 @@ import org.gradle.util.GradleVersion
  */
 @CompileStatic
 class Utils {
-  private static GradleVersion GRADLE_7_4 = GradleVersion.version("7.4")
+  private static final GradleVersion GRADLE_7_4 = GradleVersion.version("7.4")
 
   /**
    * Returns the conventional name of a configuration for a sourceSet


### PR DESCRIPTION
`IdeaModule.sourceDirs` is deprecated and scheduled for removal in Gradle 8.0.