### PR TITLE
Pass only *.proto files to protoc command

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -589,11 +589,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
 
     // Sort to ensure generated descriptors have a canonical representation
     // to avoid triggering unnecessary rebuilds downstream
-    List<File> protoFiles = sourceDirs.asFileTree
-       // quick fix for https://github.com/google/protobuf-gradle-plugin/issues/620
-      .filter { File it -> it.name.endsWith(".proto") }
-      .files
-      .sort()
+    List<File> protoFiles = sourceDirs.asFileTree.files.sort()
 
     [builtins, plugins]*.forEach { PluginOptions plugin ->
       String outputPath = getOutputDir(plugin)
@@ -608,7 +604,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
 
     // The source directory designated from sourceSet may not actually exist on disk.
     // "include" it only when it exists, so that Gradle and protoc won't complain.
-    List<String> dirs = (sourceDirs + includeDirs).filter { File it -> it.exists() }*.path
+    List<String> dirs = includeDirs.filter { File it -> it.exists() }*.path
         .collect { "-I${it}".toString() }
     logger.debug "ProtobufCompile using directories ${dirs}"
     logger.debug "ProtobufCompile using files ${protoFiles}"

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -589,7 +589,11 @@ public abstract class GenerateProtoTask extends DefaultTask {
 
     // Sort to ensure generated descriptors have a canonical representation
     // to avoid triggering unnecessary rebuilds downstream
-    List<File> protoFiles = sourceDirs.asFileTree.files.sort()
+    List<File> protoFiles = sourceDirs.asFileTree
+       // quick fix for https://github.com/google/protobuf-gradle-plugin/issues/620
+      .filter { File it -> it.name.endsWith(".proto") }
+      .files
+      .sort()
 
     [builtins, plugins]*.forEach { PluginOptions plugin ->
       String outputPath = getOutputDir(plugin)

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -381,9 +381,10 @@ class ProtobufPlugin implements Plugin<Project> {
       return project.tasks.register(generateProtoTaskName, GenerateProtoTask) {
         it.description = "Compiles Proto source for '${sourceSetOrVariantName}'".toString()
         it.outputBaseDir = outDir
-        it.addSourceDirs(protoSourceSet.asFileTree)
+        it.addSourceDirs(protoSourceSet)
         it.addIncludeDir(protoSourceSet.sourceDirectories)
         it.addSourceDirs(extractProtosDirs)
+        it.addIncludeDir(extractProtosDirs)
         it.addIncludeDir(project.files(extractIncludeProtosTask))
         configureAction.execute(it)
       }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -321,7 +321,7 @@ class ProtobufPlugin implements Plugin<Project> {
 
       // GenerateProto task, one per variant (compilation unit).
       SourceDirectorySet sourceDirs = project.objects.sourceDirectorySet(variant.name, "AllSourceSets")
-      variant.sourceDirs.forEach { sourceDirs.source(it.proto) }
+      variant.sourceSets.forEach { sourceDirs.source(it.proto) }
       FileCollection extractProtosDirs = project.files(project.providers.provider {
         variant.sourceSets.collect {
           project.files(project.tasks.named(getExtractProtosTaskName(it.name)))

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -248,7 +248,7 @@ class ProtobufPlugin implements Plugin<Project> {
       Provider<ProtobufExtract> extractIncludeProtosTask = setupExtractIncludeProtosTask(
           sourceSet.name, compileProtoPath, sourceSet.compileClasspath)
       Provider<GenerateProtoTask> generateProtoTask = addGenerateProtoTask(
-          sourceSet.name, protoSrcDirSet.sourceDirectories, project.files(extractProtosTask),
+          sourceSet.name, protoSrcDirSet, project.files(extractProtosTask),
           extractIncludeProtosTask) {
         it.sourceSet = sourceSet
         it.doneInitializing()
@@ -320,9 +320,8 @@ class ProtobufPlugin implements Plugin<Project> {
           setupExtractIncludeProtosTask(variant.name, classPathConfig, testClassPathConfig)
 
       // GenerateProto task, one per variant (compilation unit).
-      FileCollection sourceDirs = project.files(project.providers.provider {
-          variant.sourceSets.collect { it.proto.sourceDirectories }
-      })
+      SourceDirectorySet sourceDirs = project.objects.sourceDirectorySet(variant.name, "AllSourceSets")
+      variant.sourceDirs.forEach { sourceDirs.source(it.proto) }
       FileCollection extractProtosDirs = project.files(project.providers.provider {
         variant.sourceSets.collect {
           project.files(project.tasks.named(getExtractProtosTaskName(it.name)))
@@ -367,9 +366,10 @@ class ProtobufPlugin implements Plugin<Project> {
      * compiled. For Java it's the sourceSet that sourceSetOrVariantName stands
      * for; for Android it's the collection of sourceSets that the variant includes.
      */
+    @SuppressWarnings(["UnnecessaryObjectReferences"]) // suppress a lot of it.doLogic in task registration block
     private Provider<GenerateProtoTask> addGenerateProtoTask(
         String sourceSetOrVariantName,
-        FileCollection sourceDirs,
+        SourceDirectorySet protoSourceSet,
         FileCollection extractProtosDirs,
         Provider<ProtobufExtract> extractIncludeProtosTask,
         Action<GenerateProtoTask> configureAction) {
@@ -381,7 +381,8 @@ class ProtobufPlugin implements Plugin<Project> {
       return project.tasks.register(generateProtoTaskName, GenerateProtoTask) {
         it.description = "Compiles Proto source for '${sourceSetOrVariantName}'".toString()
         it.outputBaseDir = outDir
-        it.addSourceDirs(sourceDirs)
+        it.addSourceDirs(protoSourceSet.asFileTree)
+        it.addIncludeDir(protoSourceSet.sourceDirectories)
         it.addSourceDirs(extractProtosDirs)
         it.addIncludeDir(project.files(extractIncludeProtosTask))
         configureAction.execute(it)

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -37,7 +37,6 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   // Do not forget add android test
-  @Ignore("enable in 0.10.0, good fix contains breaking api change, more info #621")
   void "test generate proto task sources should include only *.proto files"() {
     given: "a project with readme file in proto source directory"
     Project project = setupBasicProject()

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -35,6 +35,23 @@ class ProtobufJavaPluginTest extends Specification {
     assert project.tasks.extractTestProto instanceof ProtobufExtract
   }
 
+  void "test generate proto task sources should include only *.proto files"() {
+    given: "a project with readme file in proto source directory"
+    Project project = setupBasicProject()
+    project.file("src/main/proto").mkdirs()
+    project.file("src/main/proto/messages.proto") << "syntax = \"proto3\";"
+    project.file("src/main/proto/README.md") << "Hello World"
+
+    when: "project evaluated"
+    project.evaluate()
+
+    then: "it contains only *.proto files"
+    assert Objects.equals(
+      project.tasks.generateProto.sourceDirs.asFileTree.files,
+      [project.file("src/main/proto/messages.proto")] as Set<File>
+    )
+  }
+
   void "testCustom sourceSet should get its own GenerateProtoTask"() {
     given: "a basic project with java and com.google.protobuf"
     Project project = setupBasicProject()

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -6,6 +6,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -35,6 +36,8 @@ class ProtobufJavaPluginTest extends Specification {
     assert project.tasks.extractTestProto instanceof ProtobufExtract
   }
 
+  // Do not forget add android test
+  @Ignore("enable in 0.10.0, good fix contains breaking api change, more info #621")
   void "test generate proto task sources should include only *.proto files"() {
     given: "a project with readme file in proto source directory"
     Project project = setupBasicProject()

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -6,7 +6,6 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -36,7 +35,6 @@ class ProtobufJavaPluginTest extends Specification {
     assert project.tasks.extractTestProto instanceof ProtobufExtract
   }
 
-  // Do not forget add android test
   void "test generate proto task sources should include only *.proto files"() {
     given: "a project with readme file in proto source directory"
     Project project = setupBasicProject()

--- a/testProjectAndroidBase/src/main/proto/README.md
+++ b/testProjectAndroidBase/src/main/proto/README.md
@@ -1,0 +1,1 @@
+Hello World

--- a/testProjectAndroidBase/src/test/proto/README.md
+++ b/testProjectAndroidBase/src/test/proto/README.md
@@ -1,0 +1,1 @@
+Hello World

--- a/testProjectBase/src/main/proto/README.md
+++ b/testProjectBase/src/main/proto/README.md
@@ -1,0 +1,1 @@
+Hello World

--- a/testProjectBase/src/test/proto/README.md
+++ b/testProjectBase/src/test/proto/README.md
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
**Background**
Non *.proto files passed to protoc exec command.

**Changes**
TLTR manual revert of https://github.com/google/protobuf-gradle-plugin/commit/407ee13063b4517dec38ef714fe9a7b21c2c41e5 

Pass includes and proto sources separately to generate proto task. 

Add README.md files to test projects to proto source dirs.

**Test plan**
Green pipelines.