### PR TITLE
Early throw if configuration not found

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -186,9 +186,9 @@ class ProtobufPlugin implements Plugin<Project> {
     private Configuration createCompileProtoPathConfiguration(String sourceSetName) {
       String compileProtoConfigName = Utils.getConfigName(sourceSetName, 'compileProtoPath')
       Configuration compileConfig =
-              project.configurations.findByName(Utils.getConfigName(sourceSetName, 'compileOnly'))
+              project.configurations.getByName(Utils.getConfigName(sourceSetName, 'compileOnly'))
       Configuration implementationConfig =
-              project.configurations.findByName(Utils.getConfigName(sourceSetName, 'implementation'))
+              project.configurations.getByName(Utils.getConfigName(sourceSetName, 'implementation'))
       return project.configurations.create(compileProtoConfigName) { Configuration it ->
           it.visible = false
           it.transitive = true


### PR DESCRIPTION
**Background**
`findByName` can return null, `getByName` throws an exception if an object with the required name is not found.
We pass the found configuration result to the `setExtendsFrom` function, this function cannot handle nullable objects. As a result, NPE will be thrown inside `setExtendsFrom` without details about the not found configuration.

**Changes**
Replace `findByName` to `getByName`

**Test plan**
Green pipelines. Not production logic was changed.

**References** 
https://github.com/google/protobuf-gradle-plugin/issues/623