### PR TITLE
Do not use compileClasspath as source of proto files

### DIFF
--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -92,6 +92,29 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
+  void "generateTestProto should not execute :compileJava task (java-only project) [gradle #gradleVersion]"() {
+    given: "project from testProject"
+    File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
+      .copyDirs('testProjectBase', 'testProject')
+      .build()
+
+    when: "build is invoked"
+    BuildResult result = ProtobufPluginTestHelper.getGradleRunner(
+      projectDir,
+      gradleVersion,
+      "generateTestProto"
+    ).build()
+
+    then: "it succeed"
+    result.task(":generateTestProto").outcome == TaskOutcome.SUCCESS
+    assert !result.output.contains("Task :classes")
+    assert !result.output.contains("Task :compileJava")
+
+    where:
+    gradleVersion << GRADLE_VERSIONS
+  }
+
+  @Unroll
   void "testProject should be successfully executed (configuration cache) [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -92,7 +92,7 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
-  void "generateTestProto should not execute :compileJava task (java-only project) [gradle #gradleVersion]"() {
+  void "test generateTestProto should not execute :compileJava task (java-only project) [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
       .copyDirs('testProjectBase', 'testProject')


### PR DESCRIPTION
**Background**
https://github.com/google/protobuf-gradle-plugin/commit/a75becdfdc2a89b414cb86fa1e8081d691d2fdc8 adds `sourceSet.compileClasspath` as dependency to `extractInclude` task. `compileClasspath` depends on `compile` tasks. That means, if we try to resolve `compileClasspath` configuration compile tasks will be executed. This creates strange behavior described here https://github.com/google/protobuf-gradle-plugin/issues/624. 

**Changes**
Do not provide proto files via `compileClasspath`, use `processResources`. Proto files were in jar via `processResources` tasks. Just use it directly, without any proxies. 

Not the best solution, I'm working on a better solution here https://github.com/google/protobuf-gradle-plugin/pull/611

**Test plan**
Green pipelines.
Manual test on https://github.com/temporalio/sdk-java/pull/1484. (no cycle found, but found licences problems. The same problem as here https://github.com/google/protobuf-gradle-plugin/issues/625)

---

Fix for https://github.com/google/protobuf-gradle-plugin/issues/624.