### PR TITLE
Emulate and deprecate generatedFilesBaseDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,12 +315,10 @@ task.plugins {
 
 ```gradle
 protobuf {
-  generatedFilesBaseDir = "$projectDir/generated"
-
   generateProtoTasks {
     all().each { task ->
       task.builtins {
-        // Generates Python code in the output folder:
+        // Generates Python code
         python { }
 
         // If you wish to avoid generating Java files:
@@ -410,7 +408,7 @@ protobuf {
 ```gradle
 { task ->
   // If true, will generate a descriptor_set.desc file under
-  // $generatedFilesBaseDir/$sourceSet. Default is false.
+  // task.outputBaseDir. Default is false.
   // See --descriptor_set_out in protoc documentation about what it is.
   task.generateDescriptorSet = true
 
@@ -430,19 +428,11 @@ protobuf {
 
 #### Change where files are generated
 
-By default generated Java files are under
-``$generatedFilesBaseDir/$sourceSet/$builtinPluginName``, where
-``$generatedFilesBaseDir`` is ``$buildDir/generated/source/proto`` by default,
-and is configurable. E.g.,
+Generated files are under `task.outputBaseDir` with a subdirectory per
+builtin and plugin. This produces a folder structure of
+``$buildDir/generated/source/proto/$sourceSet/$builtinPluginName``.
 
-```gradle
-protobuf {
-  ...
-  generatedFilesBaseDir = "$projectDir/src/generated"
-}
-```
-
-The subdirectory name, which is by default ``$builtinPluginName``, can also be
+The subdirectory name, which is by default ``$builtinPluginName``, can be
 changed by setting the ``outputSubDir`` property in the ``builtins`` or
 ``plugins`` block of a task configuration within ``generateProtoTasks`` block
 (see previous section). E.g.,
@@ -451,8 +441,7 @@ changed by setting the ``outputSubDir`` property in the ``builtins`` or
 { task ->
   task.plugins {
     grpc {
-      // Write the generated files under
-      // "$generatedFilesBaseDir/$sourceSet/grpcjava"
+      // Use subdirectory 'grpcjava' instead of the default 'grpc'
       outputSubDir = 'grpcjava'
     }
   }
@@ -519,29 +508,6 @@ Settings -> Build, Execution, Deployment
 
 This plugin integrates with the ``idea`` plugin and automatically
 registers the proto files and generated Java code as sources.
-
-
-```gradle
-apply plugin: 'idea'
-
-protobuf {
-    ...
-    generatedFilesBaseDir = "$projectDir/gen"
-}
-
-clean {
-    delete protobuf.generatedFilesBaseDir
-}
-
-idea {
-    module {
-        // proto files and generated Java files are automatically added as
-        // source dirs.
-        // If you have additional sources, add them here:
-        sourceDirs += file("/path/to/other/sources");
-    }
-}
-```
 
 
 ## Testing the plugin

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -82,9 +82,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <ruleset-ref path='rulesets/unnecessary.xml'>
     <exclude name="UnnecessaryCollectCall"/>
     <exclude name="UnnecessaryGetter"/>
+
     <exclude name="UnnecessaryGString"/>
     <exclude name="UnnecessarySetter"/>
     <exclude name="UnnecessaryPublicModifier"/>
     <exclude name="UnnecessaryReturnKeyword"/>
+
+    <!-- Poor suggestion when using static typing -->
+    <exclude name="UnnecessaryObjectReferences"/>
   </ruleset-ref>
 </ruleset>

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -587,6 +587,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   void compile() {
     Preconditions.checkState(state == State.FINALIZED, 'doneConfig() has not been called')
 
+    project.delete(outputBaseDir)
     // Sort to ensure generated descriptors have a canonical representation
     // to avoid triggering unnecessary rebuilds downstream
     List<File> protoFiles = sourceDirs.asFileTree.files.sort()

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -81,6 +81,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   static final int CMD_ARGUMENT_EXTRA_LENGTH = 3
   private static final String JAR_SUFFIX = ".jar"
 
+  private final CopyActionFacade copyActionFacade = CopyActionFacade.Loader.create(project, objectFactory)
   // include dirs are passed to the '-I' option of protoc.  They contain protos
   // that may be "imported" from the source protos, but will not be compiled.
   private final ConfigurableFileCollection includeDirs = objectFactory.fileCollection()
@@ -587,7 +588,9 @@ public abstract class GenerateProtoTask extends DefaultTask {
   void compile() {
     Preconditions.checkState(state == State.FINALIZED, 'doneConfig() has not been called')
 
-    project.delete(outputBaseDir)
+    copyActionFacade.delete { spec ->
+      spec.delete(outputBaseDir)
+    }
     // Sort to ensure generated descriptors have a canonical representation
     // to avoid triggering unnecessary rebuilds downstream
     List<File> protoFiles = sourceDirs.asFileTree.files.sort()

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
@@ -54,6 +54,8 @@ abstract class ProtobufExtension {
    * "${project.buildDir}/generated/source/proto".
    */
   private String generatedFilesBaseDir
+  @PackageScope
+  final String defaultGeneratedFilesBaseDir
 
   public ProtobufExtension(final Project project) {
     this.project = project
@@ -61,6 +63,7 @@ abstract class ProtobufExtension {
     this.tools = new ToolsLocator(project)
     this.taskConfigActions = []
     this.generatedFilesBaseDir = "${project.buildDir}/generated/source/proto"
+    this.defaultGeneratedFilesBaseDir = generatedFilesBaseDir
   }
 
   @PackageScope
@@ -81,6 +84,11 @@ abstract class ProtobufExtension {
     this.taskConfigActions.each { action ->
       action.execute(tasks)
     }
+  }
+
+  @PackageScope
+  boolean isGeneratedFilesBaseDirChanged() {
+    return generatedFilesBaseDir != defaultGeneratedFilesBaseDir
   }
 
   //===========================================================================

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
@@ -75,6 +75,7 @@ abstract class ProtobufExtension {
     return generatedFilesBaseDir
   }
 
+  @Deprecated
   void setGeneratedFilesBaseDir(String generatedFilesBaseDir) {
     this.generatedFilesBaseDir = generatedFilesBaseDir
   }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -57,7 +57,7 @@ import javax.inject.Inject
 @CompileStatic
 abstract class ProtobufExtract extends DefaultTask {
 
-  private final CopyActionFacade copyActionFacade = instantiateCopyActionFacade()
+  private final CopyActionFacade copyActionFacade = CopyActionFacade.Loader.create(project, objectFactory)
   private final ArchiveActionFacade archiveActionFacade = instantiateArchiveActionFacade()
   private final FileCollection filteredProtos = instantiateFilteredProtos()
 
@@ -97,14 +97,6 @@ abstract class ProtobufExtract extends DefaultTask {
 
   @Inject
   protected abstract ProviderFactory getProviderFactory()
-
-  private CopyActionFacade instantiateCopyActionFacade() {
-    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
-      // Use object factory to instantiate as that will inject the necessary service.
-      return objectFactory.newInstance(CopyActionFacade.FileSystemOperationsBased)
-    }
-    return new CopyActionFacade.ProjectBased(project)
-  }
 
   private ArchiveActionFacade instantiateArchiveActionFacade() {
     if (GradleVersion.current() >= GradleVersion.version("6.0")) {

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -384,7 +384,7 @@ class ProtobufPlugin implements Plugin<Project> {
       String generateProtoTaskName = 'generate' +
           Utils.getSourceSetSubstringForTaskNames(sourceSetOrVariantName) + 'Proto'
       String defaultGeneratedFilesBaseDir = protobufExtension.defaultGeneratedFilesBaseDir
-      Provider<String> generatedFilesBaseDirProvider = protobufExtension.generatedFilesBaseDirProvider
+      Provider<String> generatedFilesBaseDirProvider = protobufExtension.generatedFilesBaseDirProperty
       return project.tasks.register(generateProtoTaskName, GenerateProtoTask) {
         CopyActionFacade copyActionFacade = CopyActionFacade.Loader.create(it.project, it.objectFactory)
         it.description = "Compiles Proto source for '${sourceSetOrVariantName}'".toString()

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -384,6 +384,7 @@ class ProtobufPlugin implements Plugin<Project> {
       String generateProtoTaskName = 'generate' +
           Utils.getSourceSetSubstringForTaskNames(sourceSetOrVariantName) + 'Proto'
       return project.tasks.register(generateProtoTaskName, GenerateProtoTask) {
+        CopyActionFacade copyActionFacade = CopyActionFacade.Loader.create(it.project, it.objectFactory)
         it.description = "Compiles Proto source for '${sourceSetOrVariantName}'".toString()
         it.outputBaseDir = project.providers.provider {
           "${protobufExtension.defaultGeneratedFilesBaseDir}/${sourceSetOrVariantName}".toString()
@@ -398,7 +399,7 @@ class ProtobufPlugin implements Plugin<Project> {
             return
           }
           // Purposefully don't wire this up to outputs, as it can be mixed with other files.
-          project.copy { CopySpec spec ->
+          copyActionFacade.copy { CopySpec spec ->
             spec.includeEmptyDirs = false
             spec.from(it.outputBaseDir)
             spec.into("${protobufExtension.generatedFilesBaseDir}/${sourceSetOrVariantName}")

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -381,6 +381,7 @@ class ProtobufPlugin implements Plugin<Project> {
         FileCollection extractProtosDirs,
         Provider<ProtobufExtract> extractIncludeProtosTask,
         Action<GenerateProtoTask> configureAction) {
+      ProtobufExtension protobufExtension = this.protobufExtension;
       String generateProtoTaskName = 'generate' +
           Utils.getSourceSetSubstringForTaskNames(sourceSetOrVariantName) + 'Proto'
       return project.tasks.register(generateProtoTaskName, GenerateProtoTask) {


### PR DESCRIPTION
Fixes #33 for users not changing generatedFilesBaseDir. Stop documenting generatedFilesBaseDir since it produces poor results, but keep it functional with its existing Copy semantics. Fixes #332