### PR TITLE
Wire proto sources/outputs/etc through ProtoSourceSet

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
@@ -28,6 +28,8 @@
  */
 package com.google.protobuf.gradle
 
+import com.google.protobuf.gradle.internal.DefaultProtoSourceSet
+import com.google.protobuf.gradle.tasks.ProtoSourceSet
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.transform.TypeChecked
@@ -48,6 +50,7 @@ abstract class ProtobufExtension {
   private final GenerateProtoTaskCollection tasks
   private final ToolsLocator tools
   private final ArrayList<Action<GenerateProtoTaskCollection>> taskConfigActions
+  private final NamedDomainObjectContainer<ProtoSourceSet> sourceSets
 
   /**
    * The base directory of generated files. The default is
@@ -61,6 +64,14 @@ abstract class ProtobufExtension {
     this.tools = new ToolsLocator(project)
     this.taskConfigActions = []
     this.generatedFilesBaseDir = "${project.buildDir}/generated/source/proto"
+    this.sourceSets = project.objects.domainObjectContainer(ProtoSourceSet) { String name ->
+      new DefaultProtoSourceSet(name, project.objects) as ProtoSourceSet
+    }
+  }
+
+  @PackageScope
+  NamedDomainObjectContainer<ProtoSourceSet> getSourceSets() {
+    return this.sourceSets
   }
 
   @PackageScope

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -344,14 +344,14 @@ class ProtobufPlugin implements Plugin<Project> {
       }
       postConfigure.add {
         // This cannot be called once task execution has started.
-        variant.registerJavaGeneratingTask(
-            generateProtoTask.get(), generateProtoTask.get().getOutputSourceDirectories())
+        variant.registerJavaGeneratingTask(generateProtoTask.get(), generateProtoTask.get().outputSourceDirectories)
 
         project.plugins.withId("org.jetbrains.kotlin.android") {
           project.afterEvaluate {
             String compileKotlinTaskName = Utils.getKotlinAndroidCompileTaskName(project, variant.name)
             project.tasks.named(compileKotlinTaskName, SourceTask) { SourceTask task ->
-              task.source(variantSourceSet.output)
+              task.dependsOn(generateProtoTask)
+              task.source(generateProtoTask.get().outputSourceDirectories)
             }
           }
         }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -32,28 +32,31 @@ package com.google.protobuf.gradle
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.TestVariant
 import com.android.build.gradle.api.UnitTestVariant
+import com.android.builder.model.SourceProvider
+import com.google.protobuf.gradle.internal.DefaultProtoSourceSet
 import com.google.protobuf.gradle.internal.ProjectExt
+import com.google.protobuf.gradle.tasks.ProtoSourceSet
 import groovy.transform.CompileStatic
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.Action
 import org.gradle.api.GradleException
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.attributes.Attribute
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.internal.artifacts.ArtifactAttributes
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.util.GradleVersion
 
@@ -132,24 +135,26 @@ class ProtobufPlugin implements Plugin<Project> {
         // of each variant.
         Collection<Closure> postConfigure = []
         if (isAndroid) {
+          NamedDomainObjectContainer<ProtoSourceSet> variantMergedSourceSets =
+            project.objects.domainObjectContainer(ProtoSourceSet) { String name ->
+              new DefaultProtoSourceSet(name, project.objects) as ProtoSourceSet
+            }
           project.android.sourceSets.configureEach { sourceSet ->
-            addSourceSetExtension(sourceSet)
-            Configuration protobufConfig = createProtobufConfiguration(sourceSet.name)
-            setupExtractProtosTask(sourceSet.name, protobufConfig)
+            ProtoSourceSet protoSourceSet = protobufExtension.sourceSets.create(sourceSet.name)
+            addSourceSetExtension(sourceSet, protoSourceSet)
+            Configuration protobufConfig = createProtobufConfiguration(protoSourceSet)
+            setupExtractProtosTask(protoSourceSet, protobufConfig)
           }
           ProjectExt.forEachVariant(this.project) { BaseVariant variant ->
-            addTasksForVariant(
-              variant,
-              variant instanceof TestVariant || variant instanceof UnitTestVariant,
-              postConfigure
-            )
+            addTasksForVariant(variant, variantMergedSourceSets, postConfigure)
           }
         } else {
           project.sourceSets.configureEach { sourceSet ->
-            SourceDirectorySet protoSrcDirSet = addSourceSetExtension(sourceSet)
-            Configuration protobufConfig = createProtobufConfiguration(sourceSet.name)
-            Configuration compileProtoPath = createCompileProtoPathConfiguration(sourceSet.name)
-            addTasksForSourceSet(sourceSet, protoSrcDirSet, protobufConfig, compileProtoPath, postConfigure)
+            ProtoSourceSet protoSourceSet = protobufExtension.sourceSets.create(sourceSet.name)
+            addSourceSetExtension(sourceSet, protoSourceSet)
+            Configuration protobufConfig = createProtobufConfiguration(protoSourceSet)
+            Configuration compileProtoPath = createCompileProtoPathConfiguration(protoSourceSet)
+            addTasksForSourceSet(sourceSet, protoSourceSet, protobufConfig, compileProtoPath, postConfigure)
           }
         }
         project.afterEvaluate {
@@ -170,8 +175,8 @@ class ProtobufPlugin implements Plugin<Project> {
      * configure dependencies for it. The extract-protos task of each source set will
      * extract protobuf files from dependencies in this configuration.
      */
-    private Configuration createProtobufConfiguration(String sourceSetName) {
-      String protobufConfigName = Utils.getConfigName(sourceSetName, 'protobuf')
+    private Configuration createProtobufConfiguration(ProtoSourceSet protoSourceSet) {
+      String protobufConfigName = Utils.getConfigName(protoSourceSet.name, 'protobuf')
       return project.configurations.create(protobufConfigName) { Configuration it ->
         it.visible = false
         it.transitive = true
@@ -187,12 +192,12 @@ class ProtobufPlugin implements Plugin<Project> {
      * <p> For Java projects only.
      * <p> This works around 'java-library' plugin not exposing resources to consumers for compilation.
      */
-    private Configuration createCompileProtoPathConfiguration(String sourceSetName) {
-      String compileProtoConfigName = Utils.getConfigName(sourceSetName, 'compileProtoPath')
+    private Configuration createCompileProtoPathConfiguration(ProtoSourceSet protoSourceSet) {
+      String compileProtoConfigName = Utils.getConfigName(protoSourceSet.name, 'compileProtoPath')
       Configuration compileConfig =
-              project.configurations.getByName(Utils.getConfigName(sourceSetName, 'compileOnly'))
+              project.configurations.getByName(Utils.getConfigName(protoSourceSet.name, 'compileOnly'))
       Configuration implementationConfig =
-              project.configurations.getByName(Utils.getConfigName(sourceSetName, 'implementation'))
+              project.configurations.getByName(Utils.getConfigName(protoSourceSet.name, 'implementation'))
       return project.configurations.create(compileProtoConfigName) { Configuration it ->
           it.visible = false
           it.transitive = true
@@ -222,9 +227,9 @@ class ProtobufPlugin implements Plugin<Project> {
      * sourceSets.main.proto and sourceSets.test.proto.
      */
     @TypeChecked(TypeCheckingMode.SKIP) // Don't depend on AGP
-    private SourceDirectorySet addSourceSetExtension(Object sourceSet) {
+    private SourceDirectorySet addSourceSetExtension(Object sourceSet, ProtoSourceSet protoSourceSet) {
       String name = sourceSet.name
-      SourceDirectorySet sds = project.objects.sourceDirectorySet(name, "${name} Proto source")
+      SourceDirectorySet sds = protoSourceSet.proto
       sourceSet.extensions.add('proto', sds)
       sds.srcDir("src/${name}/proto")
       sds.include("**/*.proto")
@@ -235,40 +240,31 @@ class ProtobufPlugin implements Plugin<Project> {
      * Creates Protobuf tasks for a sourceSet in a Java project.
      */
     private void addTasksForSourceSet(
-        final SourceSet sourceSet, SourceDirectorySet protoSrcDirSet, Configuration protobufConfig,
+        SourceSet sourceSet, ProtoSourceSet protoSourceSet, Configuration protobufConfig,
         Configuration compileProtoPath, Collection<Closure> postConfigure) {
-      Provider<ProtobufExtract> extractProtosTask =
-          setupExtractProtosTask(sourceSet.name, protobufConfig)
-
-      // Pass include proto files from main to test.
-      // Process resource task contains all source proto files from a proto source set.
-      FileCollection testClassPathConfig = project.objects.fileCollection()
-      if (Utils.isTest(sourceSet.name)) {
-        TaskProvider<ProcessResources> mainProcessResources = project.tasks.named(
-          project.extensions.getByType(SourceSetContainer)
-            .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-            .processResourcesTaskName,
-          ProcessResources
-        )
-        testClassPathConfig.from(mainProcessResources)
-      }
+      Provider<ProtobufExtract> extractProtosTask = setupExtractProtosTask(protoSourceSet, protobufConfig)
 
       Provider<ProtobufExtract> extractIncludeProtosTask = setupExtractIncludeProtosTask(
-          sourceSet.name, compileProtoPath, testClassPathConfig)
-      Provider<GenerateProtoTask> generateProtoTask = addGenerateProtoTask(
-          sourceSet.name, protoSrcDirSet, project.files(extractProtosTask),
-          extractIncludeProtosTask) {
+        protoSourceSet, compileProtoPath)
+
+      // Make protos in 'test' sourceSet able to import protos from the 'main' sourceSet.
+      // Pass include proto files from main to test.
+      if (Utils.isTest(sourceSet.name)) {
+        protoSourceSet.includesFrom(protobufExtension.sourceSets.getByName("main"))
+      }
+
+      Provider<GenerateProtoTask> generateProtoTask = addGenerateProtoTask(protoSourceSet) {
         it.sourceSet = sourceSet
         it.doneInitializing()
         it.builtins.maybeCreate("java")
       }
 
-      sourceSet.java.source(sourceDirectorySetForGenerateProtoTask(sourceSet.name, generateProtoTask))
+      sourceSet.java.srcDirs(protoSourceSet.output)
 
       // Include source proto files in the compiled archive, so that proto files from
       // dependent projects can import them.
       project.tasks.named(sourceSet.getTaskName('process', 'resources'), ProcessResources).configure {
-        it.from(generateProtoTask.get().sourceDirs) { CopySpec cs ->
+        it.from(protoSourceSet.proto) { CopySpec cs ->
           cs.include '**/*.proto'
         }
       }
@@ -284,7 +280,7 @@ class ProtobufPlugin implements Plugin<Project> {
 
         project.plugins.withId("idea") {
           boolean isTest = Utils.isTest(sourceSet.name)
-          protoSrcDirSet.srcDirs.each { File protoDir ->
+          protoSourceSet.proto.srcDirs.each { File protoDir ->
             Utils.addToIdeSources(project, isTest, protoDir, false)
           }
           Utils.addToIdeSources(project, isTest, project.files(extractProtosTask).singleFile, true)
@@ -300,43 +296,40 @@ class ProtobufPlugin implements Plugin<Project> {
      * Creates Protobuf tasks for a variant in an Android project.
      */
     @TypeChecked(TypeCheckingMode.SKIP) // Don't depend on AGP
-    private void addTasksForVariant(final Object variant, boolean isTestVariant, Collection<Closure> postConfigure) {
+    private void addTasksForVariant(
+      Object variant,
+      NamedDomainObjectContainer<ProtoSourceSet> variantMergedSourceSets,
+      Collection<Closure> postConfigure
+    ) {
+      Boolean isTestVariant = Utils.isTest(variant.name)
+      ProtoSourceSet variantSourceSet = variantMergedSourceSets.create(variant.name)
+
       // ExtractIncludeProto task, one per variant (compilation unit).
       // Proto definitions from an AAR dependencies are in its JAR resources.
-      Attribute artifactType = Attribute.of("artifactType", String)
       FileCollection classPathConfig = variant.compileConfiguration.incoming.artifactView {
-        attributes {
-            it.attribute(artifactType, "jar")
-        }
+        attributes.attribute(
+          ArtifactAttributes.ARTIFACT_FORMAT,
+          ArtifactTypeDefinition.JAR_TYPE
+        )
       }.files
-      FileCollection testClassPathConfig = project.objects.fileCollection()
-      if (Utils.isTest(variant.name)) {
-        // TODO(zhangkun83): Android sourceSet doesn't have compileClasspath. If it did, we
-        // haven't figured out a way to put source protos in 'resources'. For now we use an
-        // ad-hoc solution that manually includes the source protos of 'main' and its
-        // dependencies.
-        testClassPathConfig = project.android.sourceSets['main'].proto.sourceDirectories
-        if (variant.hasProperty("testedVariant")) {
-          testClassPathConfig += variant.testedVariant.compileConfiguration.incoming.artifactView {
-                attributes {
-                    it.attribute(artifactType, "jar")
-                }
-              }.files
+
+      // Make protos in 'test' variant able to import protos from the 'main' variant.
+      // Pass include proto files from main to test.
+      if (variant instanceof TestVariant || variant instanceof UnitTestVariant) {
+        postConfigure.add {
+          variantSourceSet.includesFrom(protobufExtension.sourceSets.getByName("main"))
+          variantSourceSet.includesFrom(variantMergedSourceSets.getByName(variant.testedVariant.name))
         }
       }
-      Provider<ProtobufExtract> extractIncludeProtosTask =
-          setupExtractIncludeProtosTask(variant.name, classPathConfig, testClassPathConfig)
+
+      setupExtractIncludeProtosTask(variantSourceSet, classPathConfig)
 
       // GenerateProto task, one per variant (compilation unit).
-      SourceDirectorySet sourceDirs = project.objects.sourceDirectorySet(variant.name, "AllSourceSets")
-      variant.sourceSets.forEach { sourceDirs.source(it.proto) }
-      FileCollection extractProtosDirs = project.files(project.providers.provider {
-        variant.sourceSets.collect {
-          project.files(project.tasks.named(getExtractProtosTaskName(it.name)))
-        }
-      })
-      Provider<GenerateProtoTask> generateProtoTask = addGenerateProtoTask(
-          variant.name, sourceDirs, extractProtosDirs, extractIncludeProtosTask) {
+      variant.sourceSets.each { SourceProvider sourceProvider ->
+        variantSourceSet.extendsFrom(protobufExtension.sourceSets.getByName(sourceProvider.name))
+      }
+
+      Provider<GenerateProtoTask> generateProtoTask = addGenerateProtoTask(variantSourceSet) {
         it.setVariant(variant, isTestVariant)
         it.flavors = variant.productFlavors.collect { it.name }
         if (variant.hasProperty('buildType')) {
@@ -349,7 +342,7 @@ class ProtobufPlugin implements Plugin<Project> {
           // Include source proto files in the compiled archive, so that proto files from
           // dependent projects can import them.
           variant.getProcessJavaResourcesProvider().configure {
-            it.from(generateProtoTask.get().sourceDirs) {
+            it.from(variantSourceSet.proto) {
               include '**/*.proto'
             }
           }
@@ -374,28 +367,25 @@ class ProtobufPlugin implements Plugin<Project> {
      * compiled. For Java it's the sourceSet that sourceSetOrVariantName stands
      * for; for Android it's the collection of sourceSets that the variant includes.
      */
-    @SuppressWarnings(["UnnecessaryObjectReferences"]) // suppress a lot of it.doLogic in task registration block
     private Provider<GenerateProtoTask> addGenerateProtoTask(
-        String sourceSetOrVariantName,
-        SourceDirectorySet protoSourceSet,
-        FileCollection extractProtosDirs,
-        Provider<ProtobufExtract> extractIncludeProtosTask,
-        Action<GenerateProtoTask> configureAction) {
-      String generateProtoTaskName = 'generate' +
-          Utils.getSourceSetSubstringForTaskNames(sourceSetOrVariantName) + 'Proto'
+        ProtoSourceSet protoSourceSet,
+        Action<GenerateProtoTask> configureAction
+    ) {
+      String sourceSetName = protoSourceSet.name
+      String taskName = 'generate' + Utils.getSourceSetSubstringForTaskNames(sourceSetName) + 'Proto'
       Provider<String> outDir = project.providers.provider {
-        "${this.protobufExtension.generatedFilesBaseDir}/${sourceSetOrVariantName}".toString()
+        "${this.protobufExtension.generatedFilesBaseDir}/${sourceSetName}".toString()
       }
-      return project.tasks.register(generateProtoTaskName, GenerateProtoTask) {
-        it.description = "Compiles Proto source for '${sourceSetOrVariantName}'".toString()
+      Provider<GenerateProtoTask> task = project.tasks.register(taskName, GenerateProtoTask) {
+        it.description = "Compiles Proto source for '${sourceSetName}'".toString()
         it.outputBaseDir = outDir
-        it.addSourceDirs(protoSourceSet)
-        it.addIncludeDir(protoSourceSet.sourceDirectories)
-        it.addSourceDirs(extractProtosDirs)
-        it.addIncludeDir(extractProtosDirs)
-        it.addIncludeDir(project.files(extractIncludeProtosTask))
+        it.addSourceDirs(protoSourceSet.proto)
+        it.addIncludeDir(protoSourceSet.proto.sourceDirectories)
+        it.addIncludeDir(protoSourceSet.includeProtoDirs)
         configureAction.execute(it)
       }
+      protoSourceSet.output.from(task.map { GenerateProtoTask it -> it.outputSourceDirectories })
+      return task
     }
 
     /**
@@ -424,12 +414,18 @@ class ProtobufPlugin implements Plugin<Project> {
      * its own extraction task.
      */
     private Provider<ProtobufExtract> setupExtractProtosTask(
-        final String sourceSetName, Configuration protobufConfig) {
-      return project.tasks.register(getExtractProtosTaskName(sourceSetName), ProtobufExtract) {
+      ProtoSourceSet protoSourceSet,
+      Configuration protobufConfig
+    ) {
+      String sourceSetName = protoSourceSet.name
+      String taskName = getExtractProtosTaskName(sourceSetName)
+      Provider<ProtobufExtract> task = project.tasks.register(taskName, ProtobufExtract) {
         it.description = "Extracts proto files/dependencies specified by 'protobuf' configuration"
         it.destDir.set(getExtractedProtosDir(sourceSetName) as File)
         it.inputFiles.from(protobufConfig)
       }
+      protoSourceSet.proto.srcDir(task)
+      return task
     }
 
     private String getExtractProtosTaskName(String sourceSetName) {
@@ -444,23 +440,17 @@ class ProtobufPlugin implements Plugin<Project> {
      * <p>This task is per-sourceSet for both Java and per variant for Android.
      */
     private Provider<ProtobufExtract> setupExtractIncludeProtosTask(
-        String sourceSetOrVariantName,
-        FileCollection compileClasspathConfiguration,
-        FileCollection testedCompileClasspathConfiguration) {
-      String extractIncludeProtosTaskName = 'extractInclude' +
-          Utils.getSourceSetSubstringForTaskNames(sourceSetOrVariantName) + 'Proto'
-      return project.tasks.register(extractIncludeProtosTaskName, ProtobufExtract) {
+        ProtoSourceSet protoSourceSet,
+        FileCollection archives
+    ) {
+      String taskName = 'extractInclude' + Utils.getSourceSetSubstringForTaskNames(protoSourceSet.name) + 'Proto'
+      Provider<ProtobufExtract> task = project.tasks.register(taskName, ProtobufExtract) {
         it.description = "Extracts proto files from compile dependencies for includes"
-        it.destDir.set(getExtractedIncludeProtosDir(sourceSetOrVariantName) as File)
-        it.inputFiles.from(compileClasspathConfiguration)
-
-        // TL; DR: Make protos in 'test' sourceSet able to import protos from the 'main'
-        // sourceSet.  Sub-configurations, e.g., 'testCompile' that extends 'compile', don't
-        // depend on the their super configurations. As a result, 'testCompile' doesn't depend on
-        // 'compile' and it cannot get the proto files from 'main' sourceSet through the
-        // configuration.
-        it.inputFiles.from(testedCompileClasspathConfiguration)
+        it.destDir.set(getExtractedIncludeProtosDir(protoSourceSet.name) as File)
+        it.inputFiles.from(archives)
       }
+      protoSourceSet.includeProtoDirs.from(task)
+      return task
     }
 
     private void linkGenerateProtoTasksToTaskName(String compileTaskName, SourceDirectorySet srcDirSet) {

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -296,7 +296,7 @@ class ProtobufPlugin implements Plugin<Project> {
       NamedDomainObjectContainer<ProtoSourceSet> variantSourceSets,
       Collection<Closure> postConfigure
     ) {
-      Boolean isTestVariant = Utils.isTest(variant.name)
+      Boolean isTestVariant = variant instanceof TestVariant || variant instanceof UnitTestVariant
       ProtoSourceSet variantSourceSet = variantSourceSets.create(variant.name)
 
       // ExtractIncludeProto task, one per variant (compilation unit).

--- a/src/main/groovy/com/google/protobuf/gradle/internal/DefaultProtoSourceSet.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/internal/DefaultProtoSourceSet.groovy
@@ -1,0 +1,83 @@
+/*
+ * Original work copyright (c) 2015, Alex Antonov. All rights reserved.
+ * Modified work copyright (c) 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.protobuf.gradle.internal
+
+import com.google.protobuf.gradle.tasks.ProtoSourceSet
+import groovy.transform.CompileStatic
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.model.ObjectFactory
+
+@CompileStatic
+class DefaultProtoSourceSet implements ProtoSourceSet {
+  private final String name
+  private final SourceDirectorySet proto
+  private final ConfigurableFileCollection includeProtoDirs
+  private final ConfigurableFileCollection output
+
+  DefaultProtoSourceSet(String name, ObjectFactory objects) {
+    this.name = name
+    this.proto = objects.sourceDirectorySet("proto", "${name.capitalize()} Proto Source")
+    this.includeProtoDirs = objects.fileCollection()
+    this.output = objects.fileCollection()
+  }
+
+  @Override
+  String getName() {
+    return this.name
+  }
+
+  @Override
+  SourceDirectorySet getProto() {
+    return this.proto
+  }
+
+  @Override
+  ConfigurableFileCollection getIncludeProtoDirs() {
+    return this.includeProtoDirs
+  }
+
+  @Override
+  ConfigurableFileCollection getOutput() {
+    return this.output
+  }
+
+  @Override
+  void includesFrom(ProtoSourceSet protoSourceSet) {
+    this.includeProtoDirs.from(protoSourceSet.proto.sourceDirectories)
+    this.includeProtoDirs.from(protoSourceSet.includeProtoDirs)
+  }
+
+  @Override
+  void extendsFrom(ProtoSourceSet protoSourceSet) {
+    this.proto.source(protoSourceSet.proto)
+    this.includeProtoDirs.from(protoSourceSet.includeProtoDirs)
+  }
+}

--- a/src/main/groovy/com/google/protobuf/gradle/internal/DefaultProtoSourceSet.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/internal/DefaultProtoSourceSet.groovy
@@ -1,6 +1,5 @@
 /*
- * Original work copyright (c) 2015, Alex Antonov. All rights reserved.
- * Modified work copyright (c) 2015, Google Inc. All rights reserved.
+ * Copyright (c) 2022, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/groovy/com/google/protobuf/gradle/tasks/ProtoSourceSet.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/tasks/ProtoSourceSet.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.protobuf.gradle.tasks
+
+import groovy.transform.CompileStatic
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.SourceDirectorySet
+
+@CompileStatic
+interface ProtoSourceSet {
+  String getName()
+
+  SourceDirectorySet getProto()
+
+  ConfigurableFileCollection getIncludeProtoDirs()
+
+  ConfigurableFileCollection getOutput()
+
+  void includesFrom(ProtoSourceSet protoSourceSet)
+
+  void extendsFrom(ProtoSourceSet protoSourceSet)
+}


### PR DESCRIPTION
**Background**
To compile proto sources or java/kotlin sources, we need to combine many different tasks together.

Java examples:
1. generateProtos
sources: `from sourceSet` + `extractProtosTask`
includes: `extractIncludeProtosTask`

2. generateTestProtos
sources: `from testSourceSet` + `extractTestProtosTask`
includes: `from mainSourceSet` + `extractProtosTask` + `extractIncludeProtosTask` +  `extractIncludeTestProtosTask`

Android examples:
android part is more complicated than java. Each android variant can contains more than one sourceSet.
Let's name that sourceSet amount as `c`.

1. generateProtos
sources: `from c * sourceSet` + `c * extractProtosTask`
includes: `extractIncludeProtosTask`

2. generateTestProtos
sources: `from c * testSourceSet` + `c * extractTestProtosTask`
includes: `from c * mainSourceSet` + `c * extractTestProtosTask` + `extractIncludeProtosTask` +  `extractIncludeTestProtosTask`

It's difficult to manipulate without any structure to mix them up.

**Changes**
Added `ProtoSourceSet` structure. That structure contains all information about proto: sources, includes, outputs, tasks depends on, etc. We can easily mix source sets between. That case we need in `test` compilation (test sourceSet contains main sourceSet). All tasks that depend on `ProtoSourceSet` will inherit all dependent task declarations. 

**Test plan**
Green pipelines.

