### PR TITLE
Set default command length limit to 64k

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -76,6 +76,8 @@ public abstract class GenerateProtoTask extends DefaultTask {
   // Windows CreateProcess has command line limit of 32768:
   // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
   static final int WINDOWS_CMD_LENGTH_LIMIT = 32760
+  // Most OSs impose some kind of command length limit. Rather than account for all cases, pick a reasonable default of 64K.
+  static final int DEFAULT_CMD_LENGTH_LIMIT = 65536
   // Extra command line length when added an additional argument on Windows.
   // Two quotes and a space.
   static final int CMD_ARGUMENT_EXTRA_LENGTH = 3
@@ -207,7 +209,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   }
 
   static int getCmdLengthLimit(String os) {
-    return isWindows(os) ? WINDOWS_CMD_LENGTH_LIMIT : Integer.MAX_VALUE
+    return isWindows(os) ? WINDOWS_CMD_LENGTH_LIMIT : DEFAULT_CMD_LENGTH_LIMIT
   }
 
   static boolean isWindows(String os) {

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -76,7 +76,8 @@ public abstract class GenerateProtoTask extends DefaultTask {
   // Windows CreateProcess has command line limit of 32768:
   // https://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
   static final int WINDOWS_CMD_LENGTH_LIMIT = 32760
-  // Most OSs impose some kind of command length limit. Rather than account for all cases, pick a reasonable default of 64K.
+  // Most OSs impose some kind of command length limit.
+  // Rather than account for all cases, pick a reasonable default of 64K.
   static final int DEFAULT_CMD_LENGTH_LIMIT = 65536
   // Extra command line length when added an additional argument on Windows.
   // Two quotes and a space.

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -560,8 +560,8 @@ class ProtobufJavaPluginTest extends Specification {
 
     int limit = GenerateProtoTask.getCmdLengthLimit(os)
 
-    then: "it returns maximum integer value"
-    limit == Integer.MAX_VALUE
+    then: "it returns default limit"
+    limit == GenerateProtoTask.DEFAULT_CMD_LENGTH_LIMIT
   }
 
   private Project setupBasicProject() {


### PR DESCRIPTION
Various operating systems impose command length limits that are far short of the current Integer.MAX_VALUE default. For example, on MacOS 12.6.2, `getconf ARG_MAX` returns `1048576`. 

Hence set a reasonable default command line length limit of 64k.