### PR TITLE
Avoid OOM during tests by forking

### DIFF
--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -38,6 +38,7 @@ final class ProtobufPluginTestHelper {
       .withProjectDir(projectDir)
       .withArguments(args)
       .withGradleVersion(gradleVersion)
+      .withEnvironment(System.getenv()) // Enable forking
       .forwardStdOutput(new OutputStreamWriter(System.out))
       .forwardStdError(new OutputStreamWriter(System.err))
   }


### PR DESCRIPTION
Generally on my laptop I cannot run many of the tests before they fail with out-of-memory. With this, I can run all the tests successfully.

There does not seem to be a way to request forking directly. Instead, the docs warn about passing an environment because it will cause forking. In our case, that seems to be exactly what we want.

I believe this is a workaround and only benefitting indirectly, but it works and is easy and I'll take what I can get.