### PR TITLE
Start 0.9.3 development cycle (v1.9.x branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ buildscript {
     mavenLocal()
   }
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.2-SNAPSHOT'
+    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.3-SNAPSHOT'
   }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.github.ben-manes.versions'
 
 group = 'com.google.protobuf'
-version = '0.9.2'
+version = '0.9.3-SNAPSHOT'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
We've already started 0.10 on master, but we want to release fixes like #657 which are low risk.