### PR TITLE
build.gradle: Remove old/unnecessary repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,7 @@ ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 repositories {
     maven { url "https://plugins.gradle.org/m2/" }
-    maven { url "https://repo.gradle.org/gradle/libs-releases-local/" }
     google()
-    // Needed for resolving 'kotlinx-metadata-jvm'
-    // A transitive dependency of gradle Kotlin DSL
-    maven { url "https://kotlin.bintray.com/kotlinx/" }
 }
 
 configurations {


### PR DESCRIPTION
kotlin.bintray.com is dead and has an invalid certificate. repo.gradle.org was for gradle-kotlin-dsl which we're getting through plugins.gradle.org.