### PR TITLE
Upgrade osdetector-gradle-plugin to 1.7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   compileOnly "com.android.tools.build:gradle:4.1.0"
   compileOnly "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:1.7.22"
 
-  implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.1'
+  implementation 'com.google.gradle:osdetector-gradle-plugin:1.7.2'
 
   testImplementation 'junit:junit:4.12'
   testImplementation('org.spockframework:spock-core:1.0-groovy-2.4') {


### PR DESCRIPTION
I plan to backport this to 0.9.x for the next patch release.