### PR TITLE
Support plugins without an ExecutableLocator

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -355,7 +355,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   }
 
   private List<ExecutableLocator> getAllExecutableLocators() {
-    [toolsLocator.protoc] + plugins.collect { PluginOptions it -> toolsLocator.plugins.getByName(it.name) }
+    [toolsLocator.protoc] + plugins.findResults { PluginOptions it -> toolsLocator.plugins.findByName(it.name) }
   }
 
   @Internal("Not an actual input to the task, only used to find tasks belonging to a variant")


### PR DESCRIPTION
After upgrading from 0.8.19 to 0.9.2 I was no longer able to use plugins that would be located using the system path.

The error that was given was the following.

`> ExecutableLocator with name 'bq-schema' not found.`

This pull request attempts to enable that again by making the call that was resulting in an exception being thrown from occurring.