### PR TITLE
Delay buildDir evaluation until needed

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
@@ -38,6 +38,7 @@ import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskCollection
 
 /**
@@ -54,14 +55,16 @@ abstract class ProtobufExtension {
   private final NamedDomainObjectContainer<ProtoSourceSet> sourceSets
 
   @PackageScope
-  final String defaultGeneratedFilesBaseDir
+  final Provider<String> defaultGeneratedFilesBaseDir
 
   public ProtobufExtension(final Project project) {
     this.project = project
     this.tasks = new GenerateProtoTaskCollection(project)
     this.tools = new ToolsLocator(project)
     this.taskConfigActions = []
-    this.defaultGeneratedFilesBaseDir = "${project.buildDir}/generated/source/proto"
+    this.defaultGeneratedFilesBaseDir = project.layout.buildDirectory.dir("generated/source/proto").map {
+      it.asFile.path
+    }
     this.generatedFilesBaseDirProperty.convention(defaultGeneratedFilesBaseDir)
     this.sourceSets = project.objects.domainObjectContainer(ProtoSourceSet) { String name ->
       new DefaultProtoSourceSet(name, project.objects)

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -374,20 +374,20 @@ class ProtobufPlugin implements Plugin<Project> {
     ) {
       String sourceSetName = protoSourceSet.name
       String taskName = 'generate' + Utils.getSourceSetSubstringForTaskNames(sourceSetName) + 'Proto'
-      String defaultGeneratedFilesBaseDir = protobufExtension.defaultGeneratedFilesBaseDir
+      Provider<String> defaultGeneratedFilesBaseDir = protobufExtension.defaultGeneratedFilesBaseDir
       Provider<String> generatedFilesBaseDirProvider = protobufExtension.generatedFilesBaseDirProperty
       Provider<GenerateProtoTask> task = project.tasks.register(taskName, GenerateProtoTask) {
         CopyActionFacade copyActionFacade = CopyActionFacade.Loader.create(it.project, it.objectFactory)
         it.description = "Compiles Proto source for '${sourceSetName}'".toString()
-        it.outputBaseDir = project.providers.provider {
-          "${defaultGeneratedFilesBaseDir}/${sourceSetName}".toString()
+        it.outputBaseDir = defaultGeneratedFilesBaseDir.map {
+          "${it}/${sourceSetName}".toString()
         }
         it.addSourceDirs(protoSourceSet.proto)
         it.addIncludeDir(protoSourceSet.proto.sourceDirectories)
         it.addIncludeDir(protoSourceSet.includeProtoDirs)
         it.doLast { task ->
           String generatedFilesBaseDir = generatedFilesBaseDirProvider.get()
-          if (generatedFilesBaseDir == defaultGeneratedFilesBaseDir) {
+          if (generatedFilesBaseDir == defaultGeneratedFilesBaseDir.get()) {
             return
           }
           // Purposefully don't wire this up to outputs, as it can be mixed with other files.

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -69,6 +69,18 @@ class ProtobufJavaPluginTest extends Specification {
     assert project.tasks.extractMain2Proto instanceof ProtobufExtract
   }
 
+  void "test buildDir is late bound"() {
+    given: "a basic project with java and com.google.protobuf"
+    Project project = setupBasicProject()
+
+    when: "project evaluated"
+    project.evaluate()
+    project.buildDir = "expect-the-unexpected"
+
+    then: "generate tasks added"
+    assert project.tasks.generateProto.outputBaseDir.contains("/expect-the-unexpected/")
+  }
+
   @Unroll
   void "testProject should be successfully executed (java-only project) [gradle #gradleVersion]"() {
     given: "project from testProject"


### PR DESCRIPTION
This causes the plugin to use the correct configuration when users use a non-default buildDir.

Note that for IDEs we create directories in afterEvaluate{}. It is possible for the user's own afterEvaluate{} to change buildDir. In that case, the task will output to the 'correct' directory but the mkdirs for IDEs can be the 'old' buildDir. But users shouldn't be using afterEvaluate{}, so we don't care and there's no real fix anyway.

Fixes #674