### PR TITLE
support xxx_opt flag on protoc

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ExecutableLocator.groovy
@@ -32,6 +32,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import org.gradle.api.Named
 import org.gradle.api.file.FileCollection
+import org.gradle.util.VersionNumber
 
 /**
  * Locates an executable that can either be found locally or downloaded from
@@ -49,6 +50,8 @@ class ExecutableLocator implements Named {
 
   private FileCollection artifactFiles
   private String simplifiedArtifactName
+
+  private VersionNumber version = VersionNumber.UNKNOWN
 
   ExecutableLocator(String name) {
     this.name = name
@@ -76,12 +79,20 @@ class ExecutableLocator implements Named {
     this.artifact = null
   }
 
+  void setVersion(VersionNumber version) {
+    this.version = version
+  }
+
   String getArtifact() {
     return artifact
   }
 
   String getPath() {
     return path
+  }
+
+  VersionNumber getVersion() {
+    return version
   }
 
   @PackageScope

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -645,9 +645,15 @@ public abstract class GenerateProtoTask extends DefaultTask {
         logger.warn "protoc plugin '${name}' not defined. Trying to use 'protoc-gen-${name}' from system path"
       }
       String options = assembleOptions(plugin.options)
-      if (!options.isBlank())
-        options += ":"
-      baseCmd += "--${name}_out=${options}${getOutputDir(plugin)}".toString()
+      if (toolsLocator.protoc.version == VersionNumber.UNKNOWN ||
+              VersionNumber.parse("3.2.0") >= toolsLocator.protoc.version) {
+        if (!options.isBlank())
+          options += ":"
+        baseCmd += "--${name}_out=${options}${getOutputDir(plugin)}".toString()
+      } else {
+      baseCmd += "--${name}_out=${getOutputDir(plugin)}".toString()
+      baseCmd += "--${name}_opt=$options".toString()
+    }
     }
 
     if (generateDescriptorSet) {

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -62,6 +62,7 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
+import org.gradle.util.VersionNumber
 
 import javax.annotation.Nullable
 import javax.inject.Inject
@@ -165,7 +166,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   // - Without options: --java_out=/path/to/output
   // - With options: --java_out=option1,option2:/path/to/output
   // This method generates the prefix out of the given options.
-  static String makeOptionsPrefix(List<String> options) {
+  static String assembleOptions(List<String> options) {
     StringBuilder prefix = new StringBuilder()
     if (!options.isEmpty()) {
       options.each { option ->
@@ -174,7 +175,6 @@ public abstract class GenerateProtoTask extends DefaultTask {
         }
         prefix.append(option)
       }
-      prefix.append(':')
     }
     return prefix.toString()
   }
@@ -622,8 +622,16 @@ public abstract class GenerateProtoTask extends DefaultTask {
 
     // Handle code generation built-ins
     builtins.each { builtin ->
-      String outPrefix = makeOptionsPrefix(builtin.options)
-      baseCmd += "--${builtin.name}_out=${outPrefix}${getOutputDir(builtin)}".toString()
+      String options = assembleOptions(builtin.options)
+      if (toolsLocator.protoc.version == VersionNumber.UNKNOWN ||
+              VersionNumber.parse("3.2.0") >= toolsLocator.protoc.version) {
+        if (!options.isBlank())
+          options += ":"
+        baseCmd += "--${name}_out=${options}${getOutputDir(builtin)}".toString()
+      } else {
+        baseCmd += "--${builtin.name}_out=${getOutputDir(builtin)}".toString()
+        baseCmd += "--${builtin.name}_opt=$options".toString()
+      }
     }
 
     Map<String, ExecutableLocator> executableLocations = toolsLocator.plugins.asMap
@@ -636,8 +644,10 @@ public abstract class GenerateProtoTask extends DefaultTask {
       } else {
         logger.warn "protoc plugin '${name}' not defined. Trying to use 'protoc-gen-${name}' from system path"
       }
-      String pluginOutPrefix = makeOptionsPrefix(plugin.options)
-      baseCmd += "--${name}_out=${pluginOutPrefix}${getOutputDir(plugin)}".toString()
+      String options = assembleOptions(plugin.options)
+      if (!options.isBlank())
+        options += ":"
+      baseCmd += "--${name}_out=${options}${getOutputDir(plugin)}".toString()
     }
 
     if (generateDescriptorSet) {


### PR DESCRIPTION
This fixes the issue in https://github.com/google/protobuf-gradle-plugin/issues/210 and is based upon the work done in https://github.com/google/protobuf-gradle-plugin/pull/290.

Not sure if the last comment https://github.com/google/protobuf-gradle-plugin/issues/210#issuecomment-964901448 means that this will not be accepted, but I ran into the issue with the out flag on Windows.

What I needed was a way to pass java_multiple_files=true as option, only to learn later on that it is not possible, as it is a file option. But I already implemented this, maybe it is still useful.