### PR TITLE
GenerateProtoTask.getIsTest() is internal, not an input (v0.9.x)

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -481,7 +481,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   /**
    * Returns true if the Java source set or Android variant is test related.
    */
-  @Input
+  @Internal("Not an actual input to the task, only used to find tasks of interest")
   public boolean getIsTest() {
     return isTestProvider.get()
   }


### PR DESCRIPTION
This fixes a configuration cache incompatibility seen on Gradle 8.1 and that seemed to requiring other configuration bits as well. I have not reproduced the original issue, but a user has confirmed this fix works and the original stack trace definitely pointed to the annotation:
```
...
at com.google.protobuf.gradle.GenerateProtoTask.getIsTest(GenerateProtoTask.groovy:482)
at com.google.protobuf.gradle.GenerateProtoTask_Decorated.getIsTest(Unknown Source)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at org.gradle.internal.reflect.annotations.impl.DefaultPropertyAnnotationMetadata.getPropertyValue(DefaultPropertyAnnotationMetadata.java:97)
at org.gradle.internal.properties.annotations.DefaultTypeMetadataStore$DefaultPropertyMetadata.getPropertyValue(DefaultTypeMetadataStore.java:266)
at org.gradle.internal.properties.bean.DefaultPropertyWalker$1.lambda$visitLeaf$0(DefaultPropertyWalker.java:88)
at org.gradle.internal.deprecation.DeprecationLogger.whileDisabled(DeprecationLogger.java:258)
at org.gradle.internal.properties.bean.DefaultPropertyWalker$CachedPropertyValue.lambda$new$0(DefaultPropertyWalker.java:105)
at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:183)
at org.gradle.internal.properties.bean.DefaultPropertyWalker$CachedPropertyValue.call(DefaultPropertyWalker.java:147)
at org.gradle.util.internal.GUtil.uncheckedCall(GUtil.java:437)
at org.gradle.util.internal.DeferredUtil.unpackNestableDeferred(DeferredUtil.java:83)
at org.gradle.util.internal.DeferredUtil.unpack(DeferredUtil.java:57)
at org.gradle.util.internal.DeferredUtil.unpackOrNull(DeferredUtil.java:49)
at org.gradle.api.internal.tasks.properties.InputParameterUtils.prepareInputParameterValue(InputParameterUtils.java:38)
at org.gradle.api.internal.tasks.properties.InputParameterUtils.prepareInputParameterValue(InputParameterUtils.java:30)
...
```

Fixes #687

Backport of #691