### PR TITLE
Remove duplicate output source dir.

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -571,6 +571,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @Internal
   @PackageScope
   Collection<File> getOutputSourceDirectories() {
+    // insertion point requires the same output source directories as the java plugin. Using a set to avoid duplication.
     Collection<File> srcDirs = new HashSet<>()
     builtins.each { builtin ->
       File dir = new File(getOutputDir(builtin))

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -571,7 +571,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @Internal
   @PackageScope
   Collection<File> getOutputSourceDirectories() {
-    Collection<File> srcDirs = []
+    Collection<File> srcDirs = new HashSet<>()
     builtins.each { builtin ->
       File dir = new File(getOutputDir(builtin))
       if (!dir.name.endsWith(".zip") && !dir.name.endsWith(".jar")) {

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -572,7 +572,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @PackageScope
   Collection<File> getOutputSourceDirectories() {
     // insertion point requires the same output source directories as the java plugin. Using a set to avoid duplication.
-    Collection<File> srcDirs = new HashSet<>()
+    Collection<File> srcDirs = [] as Set
     builtins.each { builtin ->
       File dir = new File(getOutputDir(builtin))
       if (!dir.name.endsWith(".zip") && !dir.name.endsWith(".jar")) {


### PR DESCRIPTION
Remove duplicate output source dir that [breaks](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/SourceJarTask.kt;l=71) in android in source jar task.

When using the insertion point, custom plugin needs to use the same output directory as the code gen output directory from java/javalite. This causes other tasks to fail if it depends on the output source and duplicationStrategy is set to `DuplicatesStrategy.FAIL`