### PR TITLE
Fix plugin compatibility with Kotlin Gradle Plugin 1.9.0 release

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -350,13 +350,13 @@ class ProtobufPlugin implements Plugin<Project> {
         project.plugins.withId("org.jetbrains.kotlin.android") {
           // Checking if Kotlin plugin is a recent one - 1.7.20+
           if (it.respondsTo("getPluginVersion")) {
-            def kotlinExtension = project.extensions.getByType(KotlinAndroidProjectExtension.class)
+            KotlinAndroidProjectExtension kotlinExtension = project.extensions.getByType(KotlinAndroidProjectExtension)
             kotlinExtension.target.compilations.named(variant.name) {
-              defaultSourceSet.kotlin.srcDir(
-                project.objects.fileCollection().from(
-                  generateProtoTask.map { it.outputSourceDirectories }
-                )
-              )
+              it.defaultSourceSet.kotlin.srcDir { generateProtoTask.get().outputSourceDirectories }
+
+              project.tasks.named(it.compileKotlinTaskName) {
+                it.dependsOn(generateProtoTask)
+              }
             }
           } else {
             project.afterEvaluate {

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -352,11 +352,7 @@ class ProtobufPlugin implements Plugin<Project> {
           if (it.respondsTo("getPluginVersion")) {
             KotlinAndroidProjectExtension kotlinExtension = project.extensions.getByType(KotlinAndroidProjectExtension)
             kotlinExtension.target.compilations.named(variant.name) {
-              it.defaultSourceSet.kotlin.srcDir { generateProtoTask.get().outputSourceDirectories }
-
-              project.tasks.named(it.compileKotlinTaskName) {
-                it.dependsOn(generateProtoTask)
-              }
+              it.defaultSourceSet.kotlin.srcDirs(variantSourceSet.output)
             }
           } else {
             project.afterEvaluate {

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufAndroidPluginKotlinTest.groovy
@@ -8,9 +8,9 @@ import spock.lang.Unroll
 
 @CompileDynamic
 class ProtobufAndroidPluginKotlinTest extends Specification {
-  private static final List<String> GRADLE_VERSION = ["5.6", "6.5.1", "7.4.2", "7.6"]
-  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "7.2.1", "7.3.1"]
-  private static final List<String> KOTLIN_VERSION = ["1.3.20", "1.3.20", "1.3.40", "1.7.20"]
+  private static final List<String> GRADLE_VERSION = ["5.6", "6.5.1", "7.4.2", "7.6.2", "7.6.2"]
+  private static final List<String> ANDROID_PLUGIN_VERSION = ["3.5.0", "4.1.0", "7.2.1", "7.3.1", "7.4.2"]
+  private static final List<String> KOTLIN_VERSION = ["1.3.20", "1.3.20", "1.3.40", "1.7.20", "1.9.0"]
 
   /**
    * This test may take a significant amount of Gradle daemon Metaspace memory in some


### PR DESCRIPTION
Kotlin Gradle Plugin 1.9.0 release has changed how kapt tasks are configured: https://youtrack.jetbrains.com/issue/KT-54468/KAPT-Gradle-plugin-causes-eager-task-creation. Because of this change, generated proto sources are not passed to kaptGenerateStubs task leading to compilation error even in default setup.

If the Kotlin plugin version is 1.7.20 - protobuf plugin now, instead of directly configuring KotlinCompile task inputs, configures related KotlinSourceSet. This way additional sources are passed both for KotlinCompile and KaptGenerateStubs tasks.

Fixes issue #714