### PR TITLE
Avoid duplicate GenerateProtoTask output dir (v0.9.x backport)

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -571,7 +571,8 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @Internal
   @PackageScope
   Collection<File> getOutputSourceDirectories() {
-    Collection<File> srcDirs = []
+    // insertion point requires the same output source directories as the java plugin. Using a set to avoid duplication.
+    Collection<File> srcDirs = [] as Set
     builtins.each { builtin ->
       File dir = new File(getOutputDir(builtin))
       if (!dir.name.endsWith(".zip") && !dir.name.endsWith(".jar")) {


### PR DESCRIPTION
Remove duplicate output source dir that breaks in android in source jar task.

When using the insertion point, custom plugin needs to use the same output directory as the code gen output directory from java/javalite. This causes other tasks to fail if it depends on the output source and duplicationStrategy is set to `DuplicatesStrategy.FAIL`


backport of https://github.com/google/protobuf-gradle-plugin/pull/703