### PR TITLE
stop using configuration Configuration#fileCollection(Dependency...) soon to be deprecated (#716) (v0.9.x backport))

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
@@ -33,7 +33,6 @@ import groovy.transform.CompileStatic
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.Dependency
 
 /**
  * Holds locations of all external executables, i.e., protoc and plugins.
@@ -108,7 +107,7 @@ class ToolsLocator {
       classifier:classifier ?: osdetector.classifier,
       ext:extension ?: 'exe',
     ]
-    Dependency dep = project.dependencies.add(config.name, notation)
-    locator.resolve(config.fileCollection(dep), "$groupId:$artifact:$version".toString())
+    project.dependencies.add(config.name, notation)
+    locator.resolve(config, "$groupId:$artifact:$version".toString())
   }
 }


### PR DESCRIPTION
The files(Dependency...) method filters the contents of the configuration to only include files from the provided dependencies and it's transitive dependencies. Since there is only one dependency in the configuration, using this method is unnecessary.


backport of https://github.com/google/protobuf-gradle-plugin/pull/716