### PR TITLE
Start 0.9.5 development cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And in `build.gradle`:
 
 ```gradle
 plugins {
-  id "com.google.protobuf" version "0.10.0-SNAPSHOT"
+  id "com.google.protobuf" version "0.9.5-SNAPSHOT"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = 'com.google.protobuf'
-version = '0.10.0-SNAPSHOT'
+version = '0.9.5-SNAPSHOT'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
We don't need a 0.10 at the moment.

-----

Note that this is against master.

We've just been backporting all the changes to master to 0.9.x. After this, I'd delete the 0.9.x branch. We'd create a new 0.9.x branch after we have something big land.