### PR TITLE
Clean output directory before extracting protos

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -84,6 +84,9 @@ abstract class ProtobufExtract extends DefaultTask {
 
   @TaskAction
   public void extract() {
+    copyActionFacade.delete { spec ->
+      spec.delete(destDir)
+    }
     copyActionFacade.copy { spec ->
       spec.includeEmptyDirs = false
       spec.from(inputProtoFiles)


### PR DESCRIPTION
If the dependencies change, the old dependency's proto files can be left around. That is broken and causes confusion. This was noticed in #731 when a `gradle clean` was needed.