### PR TITLE
Configurable java executable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ tasks.named('test') {
   inputs.files fileTree("$projectDir/testProjectAndroidLibrary")
   inputs.files fileTree("$projectDir/testProjectBase")
   inputs.files fileTree("$projectDir/testProjectBuildTimeProto")
+  inputs.files fileTree("$projectDir/testProjectConfigureJavaExecutable")
   inputs.files fileTree("$projectDir/testProjectCustomProtoDir")
   inputs.files fileTree("$projectDir/testProjectDependent")
   inputs.files fileTree("$projectDir/testProjectDependentApp")

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
@@ -57,6 +57,9 @@ abstract class ProtobufExtension {
   @PackageScope
   final Provider<String> defaultGeneratedFilesBaseDir
 
+  @PackageScope
+  final Provider<String> defaultJavaExecutablePath
+
   public ProtobufExtension(final Project project) {
     this.project = project
     this.tasks = new GenerateProtoTaskCollection(project)
@@ -66,9 +69,21 @@ abstract class ProtobufExtension {
       it.asFile.path
     }
     this.generatedFilesBaseDirProperty.convention(defaultGeneratedFilesBaseDir)
+    this.defaultJavaExecutablePath = project.provider {
+      computeJavaExePath()
+    }
+    this.javaExecutablePath.convention(defaultJavaExecutablePath)
     this.sourceSets = project.objects.domainObjectContainer(ProtoSourceSet) { String name ->
       new DefaultProtoSourceSet(name, project.objects)
     }
+  }
+
+  static String computeJavaExePath() throws IOException {
+    File java = new File(System.getProperty("java.home"), Utils.isWindows() ? "bin/java.exe" : "bin/java")
+    if (!java.exists()) {
+      throw new IOException("Could not find java executable at " + java.path)
+    }
+    return java.path
   }
 
   @PackageScope
@@ -96,6 +111,13 @@ abstract class ProtobufExtension {
    */
   @PackageScope
   abstract Property<String> getGeneratedFilesBaseDirProperty()
+
+  /**
+   * The location of the java executable used to run java based
+   * code generation plugins. The default is the java executable
+   * running gradle.
+   */
+  abstract Property<String> getJavaExecutablePath()
 
   @PackageScope
   void configureTasks() {

--- a/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/Utils.groovy
@@ -134,4 +134,12 @@ class Utils {
       }
     }
   }
+
+  static boolean isWindows(String os) {
+    return os != null && os.toLowerCase(Locale.ROOT).indexOf("win") > -1
+  }
+
+  static boolean isWindows() {
+    return isWindows(System.getProperty("os.name"))
+  }
 }

--- a/testProjectConfigureJavaExecutable/build.gradle
+++ b/testProjectConfigureJavaExecutable/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+  id 'java'
+  id 'com.google.protobuf'
+}
+repositories { mavenCentral() }
+dependencies {
+  implementation 'com.google.protobuf:protobuf-java:3.0.0'
+}
+protobuf {
+  protoc {
+    artifact = 'com.google.protobuf:protoc:3.0.0'
+  }
+  plugins {
+    grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.0.3' }
+    grpcKotlin { artifact = 'io.grpc:protoc-gen-grpc-kotlin:1.4.1:jdk8@jar' }
+  }
+  generateProtoTasks {
+    all().configureEach { task ->
+      task.plugins {
+        grpc {}
+        grpcKotlin {}
+      }
+    }
+  }
+}

--- a/testProjectConfigureJavaExecutable/src/main/proto/com/example/tutorial/sample.proto
+++ b/testProjectConfigureJavaExecutable/src/main/proto/com/example/tutorial/sample.proto
@@ -1,0 +1,15 @@
+
+syntax = "proto3";
+
+option java_package = "com.example.tutorial";
+option java_outer_classname = "OuterSample";
+option java_multiple_files = true;
+
+message Msg {
+    string foo = 1;
+    SecondMsg blah = 2;
+}
+
+message SecondMsg {
+    int32 blah = 1;
+}


### PR DESCRIPTION
This feature was discussed in #742. The change allows a user to specify the path to a Java executable in the ProtobufExtension or the GenerateProtoTask, or both, with the task overriding the extension. If the user does not specify any task, the existing behaviour (using the java running gradle) is unchanged.

Since gradle 6.7 there is a much cleaner solution using the configured Java toolchain (see https://docs.gradle.org/current/userguide/toolchains.html#sec:plugins), I did not investigate this option since the plugin currently supports gradle versions back to 5.6.