### PR TITLE
[Fix 751] Add an experimentalEditions flag to allow use of edition to declare the proto syntax.

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -160,6 +160,12 @@ public abstract class GenerateProtoTask extends DefaultTask {
      */
     @Input
     boolean includeImports
+
+    /**
+     * If true, protobuf files will use edition to declare their syntax.
+     */
+    @Input
+    boolean experimentalEditions
   }
 
   @Internal("Handled as input via getDescriptorSetOptionsForCaching()")
@@ -644,6 +650,9 @@ public abstract class GenerateProtoTask extends DefaultTask {
       }
       if (descriptorSetOptions.includeSourceInfo) {
         baseCmd += "--include_source_info"
+      }
+      if (descriptorSetOptions.experimentalEditions) {
+        baseCmd += "--experimental_editions"
       }
     }
 


### PR DESCRIPTION
- See https://protobuf.dev/editions/overview/