### PR TITLE
Inline deprecated constant value

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -47,12 +47,12 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.artifacts.ArtifactAttributes
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
@@ -307,7 +307,7 @@ class ProtobufPlugin implements Plugin<Project> {
       // Proto definitions from an AAR dependencies are in its JAR resources.
       FileCollection classPathConfig = variant.compileConfiguration.incoming.artifactView {
         attributes.attribute(
-          ArtifactAttributes.ARTIFACT_FORMAT,
+          Attribute.of("artifactType", String),
           ArtifactTypeDefinition.JAR_TYPE
         )
       }.files


### PR DESCRIPTION
We are removing the deprecated `ArtifactAttributes` class from Gradle.

It is still used here: https://github.com/google/protobuf-gradle-plugin/blob/master/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy#L310.

It can be replaced by `Attribute.of("artifactType", String)`.  This PR does this.

Or, if you upgrade your build to Gradle >= 7.3, you can use the predefined `ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE`.