### PR TITLE
Use ArchiveOperations instead of internal FileOperations, when available

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ArchiveActionFacade.java
+++ b/src/main/groovy/com/google/protobuf/gradle/ArchiveActionFacade.java
@@ -30,6 +30,7 @@ package com.google.protobuf.gradle;
 
 import groovy.transform.CompileStatic;
 import org.gradle.api.Project;
+import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileOperations;
 
@@ -63,9 +64,8 @@ public interface ArchiveActionFacade {
     }
 
     @CompileStatic
-    abstract class ServiceBased implements ArchiveActionFacade {
+    abstract class InternalServiceBased implements ArchiveActionFacade {
 
-        // TODO Use public ArchiveOperations from Gradle 6.6 instead
         @Inject
         public abstract FileOperations getFileOperations();
 
@@ -77,6 +77,23 @@ public interface ArchiveActionFacade {
         @Override
         public FileTree tarTree(Object path) {
             return getFileOperations().tarTree(path);
+        }
+    }
+
+    @CompileStatic
+    abstract class ServiceBased implements ArchiveActionFacade {
+
+        @Inject
+        public abstract ArchiveOperations getArchiveOperations();
+
+        @Override
+        public FileTree zipTree(Object path) {
+            return getArchiveOperations().zipTree(path);
+        }
+
+        @Override
+        public FileTree tarTree(Object path) {
+            return getArchiveOperations().tarTree(path);
         }
     }
 }

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtract.groovy
@@ -102,9 +102,13 @@ abstract class ProtobufExtract extends DefaultTask {
   protected abstract ObjectFactory getObjectFactory()
 
   private ArchiveActionFacade instantiateArchiveActionFacade() {
-    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
       // Use object factory to instantiate as that will inject the necessary service.
       return objectFactory.newInstance(ArchiveActionFacade.ServiceBased)
+    }
+    if (GradleVersion.current() >= GradleVersion.version("6.0")) {
+      // Use object factory to instantiate as that will inject the necessary service.
+      return objectFactory.newInstance(ArchiveActionFacade.InternalServiceBased)
     }
     return new ArchiveActionFacade.ProjectBased(project)
   }


### PR DESCRIPTION
The internal usage was added in c425e558f with the expectation that we'd move to ArchiveOperations when it was available.

@kannanjgithub

(Side note: we really need to update which Gradle versions we test against, and drop support for some)