### PR TITLE
Cleanup testProjectKotlinDslBase imports

### DIFF
--- a/testProjectKotlinDslBase/build.gradle.kts
+++ b/testProjectKotlinDslBase/build.gradle.kts
@@ -1,6 +1,4 @@
-import com.google.protobuf.gradle.*
-import org.gradle.api.internal.HasConvention
-import org.gradle.kotlin.dsl.provider.gradleKotlinDslOf
+import com.google.protobuf.gradle.id
 
 plugins {
     java


### PR DESCRIPTION
This removes an import to an internal Gradle API. The Gradle imports appear to have been unused when introduced.

------

This is the last "usage" of an internal Gradle class that I see by grepping.

@kannanjgithub