### PR TITLE
Fix deprecated API usage in ToolsLocator

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
@@ -100,13 +100,9 @@ class ToolsLocator {
     OsDetector osdetector = project.extensions.getByName("osdetector") as OsDetector
     List<String> parts = artifactParts(locator.artifact)
     (groupId, artifact, version, classifier, extension) = [parts[0], parts[1], parts[2], parts[3], parts[4]]
-    Map<String, String> notation = [
-      group:groupId,
-      name:artifact,
-      version:version,
-      classifier:classifier ?: osdetector.classifier,
-      ext:extension ?: 'exe',
-    ]
+    classifier = classifier ?: osdetector.classifier
+    extension = extension ?: "exe"
+    String notation = "$groupId:$artifact:$version:$classifier@${extension}"
     project.dependencies.add(config.name, notation)
     locator.resolve(config, "$groupId:$artifact:$version".toString())
   }


### PR DESCRIPTION
Gradle 9.1 deprecates declaring dependencies using multi-string notation.
Instead single-string notation should be used instead.

See https://docs.gradle.org/9.1.0-rc-2/userguide/upgrading_version_9.html#dependency_multi_string_notation for details.

This fixes the ToolLocator by using the prefered single-string notation now