### PR TITLE
fix: empty versions are represented by "" and not by "null"

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
@@ -100,6 +100,7 @@ class ToolsLocator {
     OsDetector osdetector = project.extensions.getByName("osdetector") as OsDetector
     List<String> parts = artifactParts(locator.artifact)
     (groupId, artifact, version, classifier, extension) = [parts[0], parts[1], parts[2], parts[3], parts[4]]
+    version = version ?: ''
     classifier = classifier ?: osdetector.classifier
     extension = extension ?: "exe"
     String notation = "$groupId:$artifact:$version:$classifier@${extension}"


### PR DESCRIPTION
This fixes a small regression introduced with #786.

The problem surfaces when you define tool dependencies without versions. This is the case in a setup where you want to manage the versions outside of the protobuf plugin configuration – for example through a _java-platform_ project. We have such a setup [here](https://github.com/hiero-ledger/hiero-gradle-conventions/blob/892efc40e1fb047e34136263d89b883bd2039881/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts). 

In that case, `version` – coming our of `artifactParts(locator.artifact)` – is `null`. The newly introduced `$version` currently turns this into a `"null"` String, while it should be `""` (empty string) which is the correct representation of "no version".

What happens currently is that Gradle thinks `"null"` is a valid version identifier and tries to download metadata for each tool with the version `"null"`. This fails. Since fails are not cached, it tries this again on every build invocation. It does not lead to an error, because the version is never used in the end. The (failing) metadata download is an intermediate step in the version conflict detection. However, this slows down build as it happens over and over again. The workaround (as we did [here](https://github.com/hiero-ledger/hiero-gradle-conventions/pull/410)) is to define some existing version so that the (unused) metadata is downloaded once and cached. 

@breskeby @eskatos FYI