### PR TITLE
Enable parallel tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,8 @@ tasks.named('test') {
 
   useJUnitPlatform()
 
+  maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+
   testLogging {
     events = ["standard_out", "standard_error", "started", "passed", "failed", "skipped"]
   }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufPluginTestHelper.groovy
@@ -118,9 +118,8 @@ final class ProtobufPluginTestHelper {
     }
 
     File build() {
-      File projectDir = new File(System.getProperty('user.dir'), 'build/tests/' + testProjectName)
-      FileUtils.deleteDirectory(projectDir)
-      FileUtils.forceMkdir(projectDir)
+      File projectDir = new File(File.createTempDir(), testProjectName)
+      projectDir.mkdirs()
       sourceDirs.each { String dir ->
         FileUtils.copyDirectory(new File(System.getProperty("user.dir"), dir), projectDir)
       }


### PR DESCRIPTION
- Update ProtobufPluginTestHelper to use a unique temporary directory for running Gradle tests. Skipping this step causes collisions when tests execute concurrently.
- Set maxParallelForks for the test task to allow for parallel test execution.

On a high end machine test task goes from 17m 21s to 6m 49s

Test: ./gradlew test --rerun-tasks
      Before: https://scans.gradle.com/s/gnmeso74olfnk/timeline?details=si6uhuz4tdufw
      After: https://scans.gradle.com/s/4ym44hvuc7gds/timeline?details=si6uhuz4tdufw