### PR TITLE
Revert back to observing generatedFilesBaseDir, but make it read-only

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufExtension.groovy
@@ -37,7 +37,7 @@ import groovy.transform.TypeCheckingMode
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskCollection
@@ -56,9 +56,6 @@ abstract class ProtobufExtension {
   private final NamedDomainObjectContainer<ProtoSourceSet> sourceSets
 
   @PackageScope
-  final Provider<String> defaultGeneratedFilesBaseDir
-
-  @PackageScope
   final Provider<String> defaultJavaExecutablePath
 
   public ProtobufExtension(final Project project) {
@@ -66,10 +63,8 @@ abstract class ProtobufExtension {
     this.tasks = new GenerateProtoTaskCollection(project)
     this.tools = new ToolsLocator(project)
     this.taskConfigActions = []
-    this.defaultGeneratedFilesBaseDir = project.layout.buildDirectory.dir("generated/sources/proto").map {
-      Directory dir -> dir.asFile.path
-    }
-    this.generatedFilesBaseDirProperty.convention(defaultGeneratedFilesBaseDir)
+    this.generatedFilesBaseDirProperty.convention(
+        project.layout.buildDirectory.dir("generated/sources/proto"))
     this.defaultJavaExecutablePath = project.provider {
       computeJavaExePath()
     }
@@ -98,12 +93,7 @@ abstract class ProtobufExtension {
   }
 
   String getGeneratedFilesBaseDir() {
-    return generatedFilesBaseDirProperty.get()
-  }
-
-  @Deprecated
-  void setGeneratedFilesBaseDir(String generatedFilesBaseDir) {
-    generatedFilesBaseDirProperty.set(generatedFilesBaseDir)
+    return generatedFilesBaseDirProperty.get().asFile.path
   }
 
   /**
@@ -111,7 +101,7 @@ abstract class ProtobufExtension {
    * "${project.buildDir}/generated/sources/proto".
    */
   @PackageScope
-  abstract Property<String> getGeneratedFilesBaseDirProperty()
+  abstract DirectoryProperty getGeneratedFilesBaseDirProperty()
 
   /**
    * The location of the java executable used to run java based

--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -298,30 +298,15 @@ class ProtobufPlugin implements Plugin<Project> {
     ) {
       String sourceSetName = protoSourceSet.name
       String taskName = 'generate' + Utils.getSourceSetSubstringForTaskNames(sourceSetName) + 'Proto'
-      Provider<String> defaultGeneratedFilesBaseDir = protobufExtension.defaultGeneratedFilesBaseDir
-      Provider<String> generatedFilesBaseDirProvider = protobufExtension.generatedFilesBaseDirProperty
+      DirectoryProperty generatedFilesBaseDirProperty = protobufExtension.generatedFilesBaseDirProperty
       Provider<GenerateProtoTask> task = project.tasks.register(taskName, GenerateProtoTask) {
         GenerateProtoTask protoTask ->
-        CopyActionFacade copyActionFacade = CopyActionFacade.Loader.create(protoTask.project, protoTask.objectFactory)
         protoTask.description = "Compiles Proto source for '${sourceSetName}'".toString()
         protoTask.addSourceDirs(protoSourceSet.proto)
         protoTask.addIncludeDir(protoSourceSet.proto.sourceDirectories)
         protoTask.addIncludeDir(protoSourceSet.includeProtoDirs)
         protoTask.outputBaseDirProperty.convention(
-            project.layout.buildDirectory.dir("generated/sources/proto/${sourceSetName}")
-        )
-        protoTask.doLast {
-          String generatedFilesBaseDir = generatedFilesBaseDirProvider.get()
-          if (generatedFilesBaseDir == defaultGeneratedFilesBaseDir.get()) {
-            return
-          }
-          // Purposefully don't wire this up to outputs, as it can be mixed with other files.
-          copyActionFacade.copy { CopySpec spec ->
-            spec.includeEmptyDirs = false
-            spec.from(protoTask.outputBaseDirProperty)
-            spec.into("${generatedFilesBaseDir}/${sourceSetName}")
-          }
-        }
+            generatedFilesBaseDirProperty.dir(sourceSetName))
         configureAction.execute(protoTask)
       }
       protoSourceSet.output.from(task.map { GenerateProtoTask t -> t.outputSourceDirectories })


### PR DESCRIPTION
137e5c3a5 simply started ignoring ProtobufExtension's configured generated directory. Setting the directory was deprecated in v0.9.2 in early 2023, so let's trash it instead of continuing to emulate it. It seems people are reading from generatedFilesBaseDir, so let's preserve it for now; long-term I do suspect we'd delete it as well.

CC @omarismail94, @liutikas