### PR TITLE
Disable caching for internal ProtoSyncTask

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ProtobufPlugin.groovy
@@ -57,6 +57,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GradleVersion
+import org.gradle.work.DisableCachingByDefault
 import javax.inject.Inject
 
 /**
@@ -375,6 +376,7 @@ class ProtobufPlugin implements Plugin<Project> {
       return "${project.buildDir}/extracted-protos/${sourceSetName}"
     }
 
+    @DisableCachingByDefault(because="Just copies files")
     @PackageScope
     abstract static class ProtoSyncTask extends DefaultTask {
       @Inject abstract FileSystemOperations getFileSystem()


### PR DESCRIPTION
137e5c3a5 swapped from modifying Java plugin's ProcessResources to using a separate task. ProcessResources has `@DisableCachingByDefault` and copying files is the canonical example for disabling caching, so do that on the new task.

CC @omarismail94, @liutikas